### PR TITLE
feat: Support demo scheme for KVK during development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,4 @@
 services:
-  demo-schemes:
-    container_name: yivi-portal-demo-schemes
-    image: ghcr.io/privacybydesign/irma:edge
-    command: >
-      scheme download /schemes https://schemes.staging.yivi.app/pbdf-staging
-    volumes:
-      - ./downloads/schemes:/schemes
-
   yivi:
     container_name: yivi-portal-yivi
     image: ghcr.io/privacybydesign/irma:edge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,12 @@
 services:
+  demo-schemes:
+    container_name: yivi-portal-demo-schemes
+    image: ghcr.io/privacybydesign/irma:edge
+    command: >
+      scheme download /schemes https://schemes.staging.yivi.app/pbdf-staging
+    volumes:
+      - ./downloads/schemes:/schemes
+
   yivi:
     container_name: yivi-portal-yivi
     image: ghcr.io/privacybydesign/irma:edge
@@ -9,8 +17,11 @@ services:
       - web
     ports:
       - 8080:8080
+    volumes:
+      - ./downloads/schemes:/schemes
     environment:
       YIVI_SERVER_TOKEN: ${YIVI_SERVER_TOKEN}
+      IRMASERVER_SCHEMES_PATH: /schemes
 
   database:
     image: postgres:13.3-alpine

--- a/schememanager/forms/verifier.py
+++ b/schememanager/forms/verifier.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django import forms
 from django.forms import ModelForm
 from fqdn import FQDN
@@ -79,7 +80,7 @@ class VerifierSessionRequestAddForm(ModelForm):
         self.fields["condiscon"].widget.attrs["placeholder"] = json.dumps(
             {
                 "@context": "https://irma.app/ld/request/disclosure/v2",
-                "disclose": [[["pbdf.sidn-pbdf.email.email"]]],
+                "disclose": settings.EMAIL_DISCLOSURE,
             }
         )
 

--- a/schememanager/views/login.py
+++ b/schememanager/views/login.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib.auth import get_user_model, login, logout
 from django.dispatch import receiver
 from django.shortcuts import redirect
@@ -19,7 +20,7 @@ class LoginView(TemplateView):
 
     yivi_request = {
         "@context": "https://irma.app/ld/request/disclosure/v2",
-        "disclose": [[["pbdf.sidn-pbdf.email.email"]]],
+        "disclose": settings.EMAIL_DISCLOSURE,
     }
 
     success_url = reverse_lazy("schememanager:organization-list")

--- a/schememanager/views/organization.py
+++ b/schememanager/views/organization.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import timedelta
 
+from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.dispatch import receiver
@@ -29,35 +30,7 @@ class RegistrationView(TemplateView):
 
     yivi_request = {
         "@context": "https://irma.app/ld/request/disclosure/v2",
-        "disclose": [
-            [
-                [
-                    "pbdf.signicat.kvkTradeRegister.kvkNumber",
-                    "pbdf.signicat.kvkTradeRegister.name",
-                    "pbdf.signicat.kvkTradeRegister.tradeNames",
-                    "pbdf.signicat.kvkTradeRegister.typeOwner",
-                    "pbdf.signicat.kvkTradeRegister.legalEntity",
-                    "pbdf.signicat.kvkTradeRegister.address",
-                    "pbdf.signicat.kvkTradeRegister.emailAddress",
-                    "pbdf.signicat.kvkTradeRegister.phone",
-                    "pbdf.signicat.kvkTradeRegister.registrationStart",
-                    "pbdf.signicat.kvkTradeRegister.dateDeregistration",
-                    "pbdf.signicat.kvkTradeRegister.registrationEnd",
-                    "pbdf.signicat.kvkTradeRegister.specialLegalSituation",
-                    "pbdf.signicat.kvkTradeRegister.restrictionInLegalAction",
-                    "pbdf.signicat.kvkTradeRegister.foreignLegalStatus",
-                    "pbdf.signicat.kvkTradeRegister.hasRestriction",
-                    "pbdf.signicat.kvkTradeRegister.isAuthorized",
-                    "pbdf.signicat.kvkTradeRegister.reason",
-                    "pbdf.signicat.kvkTradeRegister.referenceMoment",
-                ]
-            ],
-            [
-                [
-                    "pbdf.sidn-pbdf.email.email",
-                ]
-            ],
-        ],
+        "disclose": settings.KVK_DISCLOSURE
     }
 
     def get_context_data(self, **kwargs):

--- a/yivi_portal/settings/development.py
+++ b/yivi_portal/settings/development.py
@@ -32,7 +32,7 @@ MEDIA_ROOT = BASE_DIR / "assets"
 
 EMAIL_DISCLOSURE = [
     [
-        [ "pbdf-staging.sidn-pbdf.email.email" ]
+        [ "irma-demo.sidn-pbdf.email.email" ]
     ]
 ]
 
@@ -61,7 +61,7 @@ KVK_DISCLOSURE = [
     ],
     [
         [
-            "pbdf-staging.sidn-pbdf.email.email"
+            "irma-demo.sidn-pbdf.email.email"
         ]
     ],
 ]

--- a/yivi_portal/settings/development.py
+++ b/yivi_portal/settings/development.py
@@ -29,3 +29,39 @@ MEDIA_URL = "assets/"
 
 STATIC_ROOT = BASE_DIR / "static"
 MEDIA_ROOT = BASE_DIR / "assets"
+
+EMAIL_DISCLOSURE = [
+    [
+        [ "pbdf-staging.sidn-pbdf.email.email" ]
+    ]
+]
+
+KVK_DISCLOSURE = [
+    [
+        [
+            "irma-demo.kvk.official.kvkNumber",
+            "irma-demo.kvk.official.name",
+            "irma-demo.kvk.official.tradeNames",
+            "irma-demo.kvk.official.typeOwner",
+            "irma-demo.kvk.official.legalEntity",
+            "irma-demo.kvk.official.officeAddress",
+            "irma-demo.kvk.official.emailAddress",
+            "irma-demo.kvk.official.officePhone",
+            "irma-demo.kvk.official.registrationStart",
+            "irma-demo.kvk.official.dateDeregistration",
+            "irma-demo.kvk.official.registrationEnd",
+            "irma-demo.kvk.official.specialLegalSituation",
+            "irma-demo.kvk.official.restrictionInLegalAction",
+            "irma-demo.kvk.official.foreignLegalStatus",
+            "irma-demo.kvk.official.hasRestriction",
+            "irma-demo.kvk.official.isAuthorized",
+            "irma-demo.kvk.official.reason",
+            "irma-demo.kvk.official.referenceMoment",
+        ]
+    ],
+    [
+        [
+            "pbdf-staging.sidn-pbdf.email.email"
+        ]
+    ],
+]

--- a/yivi_portal/settings/production.py
+++ b/yivi_portal/settings/production.py
@@ -32,3 +32,39 @@ MEDIA_URL = os.environ.get("DJANGO_MEDIA_URL")
 
 STATIC_ROOT = os.environ.get("DJANGO_STATIC_ROOT")
 MEDIA_ROOT = os.environ.get("DJANGO_MEDIA_ROOT")
+
+EMAIL_DISCLOSURE = [
+    [
+        [ "pbdf.sidn-pbdf.email.email" ]
+    ]
+]
+
+KVK_DISCLOSURE = [
+    [
+        [
+            "pbdf.signicat.kvkTradeRegister.kvkNumber",
+            "pbdf.signicat.kvkTradeRegister.name",
+            "pbdf.signicat.kvkTradeRegister.tradeNames",
+            "pbdf.signicat.kvkTradeRegister.typeOwner",
+            "pbdf.signicat.kvkTradeRegister.legalEntity",
+            "pbdf.signicat.kvkTradeRegister.address",
+            "pbdf.signicat.kvkTradeRegister.emailAddress",
+            "pbdf.signicat.kvkTradeRegister.phone",
+            "pbdf.signicat.kvkTradeRegister.registrationStart",
+            "pbdf.signicat.kvkTradeRegister.dateDeregistration",
+            "pbdf.signicat.kvkTradeRegister.registrationEnd",
+            "pbdf.signicat.kvkTradeRegister.specialLegalSituation",
+            "pbdf.signicat.kvkTradeRegister.restrictionInLegalAction",
+            "pbdf.signicat.kvkTradeRegister.foreignLegalStatus",
+            "pbdf.signicat.kvkTradeRegister.hasRestriction",
+            "pbdf.signicat.kvkTradeRegister.isAuthorized",
+            "pbdf.signicat.kvkTradeRegister.reason",
+            "pbdf.signicat.kvkTradeRegister.referenceMoment",
+        ]
+    ],
+    [
+        [
+            "pbdf.sidn-pbdf.email.email"
+        ]
+    ],
+]


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` configuration and several updates to the `schememanager` and `yivi_portal` Django settings to enhance the handling of disclosure settings. The most important changes include adding a new service to the Docker configuration and refactoring the disclosure settings to use Django settings.

### Docker Configuration Changes:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R2-R9): Added a new `demo-schemes` service to download schemes from a specified URL and updated the `yivi` service to include the schemes volume and environment variable. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R2-R9) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R20-R24)

### Disclosure Settings Refactoring:
* [`schememanager/forms/verifier.py`](diffhunk://#diff-a261a9f4d74c7e4d8b5465aefee7c44245e562416c0af1ed69224509609f0ca4L82-R83): Changed the hardcoded email disclosure to use `settings.EMAIL_DISCLOSURE`.
* [`schememanager/views/login.py`](diffhunk://#diff-c9e06e64b2c2787fe66c1501d1654cbac7664f525214e1b748ef5ffb7caa96a1L22-R23): Updated the `yivi_request` to use `settings.EMAIL_DISCLOSURE` instead of hardcoded values.
* [`schememanager/views/organization.py`](diffhunk://#diff-de7164ecd18af796a8b5a5a3a6d6333250cb25f257bc358fcf4463e754298673L32-R33): Refactored the `yivi_request` to use `settings.KVK_DISCLOSURE` for the registration view.
* `yivi_portal/settings/development.py` and `yivi_portal/settings/production.py`: Added `EMAIL_DISCLOSURE` and `KVK_DISCLOSURE` settings to store disclosure configuration. [[1]](diffhunk://#diff-3bd91a74f0a7405140c6d315ecebce6f2dee1e441602400242d26190bb4d9238R32-R67) [[2]](diffhunk://#diff-e8ca0cb019c2b9fd28b77540ceb4d973570c564328cdd13cce9cd13c66bd9144R35-R70)

Closes #6