### PR TITLE
fix: Enable users who are not an admin to logout

### DIFF
--- a/schememanager/views/login.py
+++ b/schememanager/views/login.py
@@ -85,8 +85,6 @@ class LogoutView(RedirectView):
         if request.session["yivi_email"]:
             del self.request.session["yivi_email"]
 
-            logger.info(f"User with email {request.user.email} logged out.")
-
         if request.user.is_authenticated:
             logout(request)
         return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
The user object is not available when the user is logged in with Yivi
and is not attached to a Django user object.

