### PR TITLE
missing base settings import

### DIFF
--- a/yivi_portal/settings/production.py
+++ b/yivi_portal/settings/production.py
@@ -1,3 +1,4 @@
+from base import *  # noqa: F405, F403
 import os
 
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")


### PR DESCRIPTION
The production settings, used in `asgi.py` and `wsgi.py`, is not importing the `base` settings.