### PR TITLE
Portal improvements

### DIFF
--- a/portal_backend/models/model_serializers.py
+++ b/portal_backend/models/model_serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from .models import (
     Organization,
     TrustModel,
+    User,
     YiviTrustModelEnv,
     Status,
     RelyingPartyHostname,
@@ -120,4 +121,9 @@ class RelyingPartySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = RelyingParty
+        fields = "__all__"
+
+class MaintainerSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
         fields = "__all__"

--- a/portal_backend/views/helpers.py
+++ b/portal_backend/views/helpers.py
@@ -1,32 +1,44 @@
+import logging
 from rest_framework import permissions
 from django.shortcuts import get_object_or_404
-from ..models.models import RelyingParty, User, Organization
+from ..models.models import User
+
+logger = logging.getLogger(__name__)
+
+class ORPermission(permissions.BasePermission):
+    def __init__(self, *perms):
+        self.perms = perms
+
+    def has_permission(self, request, view):
+        return any(perm().has_permission(request, view) for perm in self.perms)
+
+    def has_object_permission(self, request, view, obj):
+        return any(perm().has_object_permission(request, view, obj) for perm in self.perms)
 
 
-class IsMaintainer(permissions.BasePermission):
+class IsMaintainerOrAdmin(permissions.BasePermission):
     message = "Unauthorized: User does not have maintainer permissions"
 
     def has_permission(self, request, view):
         user_obj = get_object_or_404(User, email=request.user.email)
-        return user_obj.role == "maintainer"
+        return user_obj.role == "maintainer" or user_obj.role == "admin"
 
 
 class BelongsToOrganization(permissions.BasePermission):
     message = "Unauthorized: User does not belong to this organization"
 
     def has_permission(self, request, view):
-        org_pk = view.kwargs.get("org_pk")
-        slug = view.kwargs.get("slug")
+        logger.info(view.kwargs)
+        org_pk = view.kwargs.get("pk")
+        if org_pk is None:
+            return False
+        
+        logger.info("Checking if user belongs to organization with id: " + str(org_pk))
 
         user_obj = get_object_or_404(User, email=request.user.email)
+        if user_obj.role == "admin":
+            return True
+        if user_obj.organization.id == org_pk:
+            return True
 
-        if org_pk:
-            return str(user_obj.organization.id) == str(org_pk)
-        elif slug:
-            try:
-                organization = Organization.objects.get(slug=slug)
-                return user_obj.organization.id == organization.id
-            except RelyingParty.DoesNotExist:
-                return False
-
-        return True  # if no org id found, skip this check
+        return False

--- a/portal_backend/views/organization.py
+++ b/portal_backend/views/organization.py
@@ -4,16 +4,26 @@ from rest_framework.response import Response
 from drf_yasg.utils import swagger_auto_schema  # type: ignore
 from rest_framework import status
 from ..models.model_serializers import OrganizationSerializer
-from ..models.models import Organization
+from ..models.models import AttestationProvider, Organization, RelyingParty
 from rest_framework import permissions
 from ..models.models import User
 from .helpers import BelongsToOrganization, IsMaintainer
 from rest_framework.pagination import LimitOffsetPagination
 from drf_yasg import openapi  # type: ignore
 from django.shortcuts import get_object_or_404
+from django.db.models import Exists, OuterRef, Q
 
 logger = logging.getLogger(__name__)
 
+def to_nullable_bool(value: str | None):
+        if value is None:
+            return None
+        value = value.lower()
+        if value == "true":
+            return True
+        if value == "false":
+            return False
+        return None
 
 class OrganizationListAPIView(APIView):
     permission_classes = [permissions.AllowAny]
@@ -24,12 +34,32 @@ class OrganizationListAPIView(APIView):
 
         logger.info("Fetching all registered organizations")
 
-        orgs = Organization.objects.filter(is_verified=True)
-
         search_query = request.query_params.get("search")
         trust_model = request.query_params.get("trust_model")
-        is_ap = request.query_params.get("is_ap", None)
-        is_rp = request.query_params.get("is_rp", None)
+        select_aps = to_nullable_bool(request.query_params.get("ap"))
+        select_rps = to_nullable_bool(request.query_params.get("rp"))
+        
+        # If both select_aps and select_rps are False, return an empty list
+        if (select_aps is False and select_rps is False):
+            paginator = LimitOffsetPagination()
+            paginator.default_limit = 20
+            result_page = paginator.paginate_queryset([], request)
+            serializer = OrganizationSerializer(result_page, many=True)
+            return paginator.get_paginated_response(serializer.data)
+        
+        orgs = Organization.objects.annotate(
+            is_rp=Exists(
+                RelyingParty.objects.filter(organization=OuterRef('pk'))
+            ),
+            is_ap=Exists(
+                AttestationProvider.objects.filter(organization=OuterRef('pk'))
+            )
+        ).filter(
+            is_verified=True
+        ).filter(
+            (Q(is_rp=select_rps) if select_rps is not None else Q()) |
+            (Q(is_ap=select_aps) if select_aps is not None else Q())
+        ).order_by('name_en')
 
         if search_query:
             orgs = orgs.filter(name_en__icontains=search_query) | orgs.filter(
@@ -37,10 +67,6 @@ class OrganizationListAPIView(APIView):
             )
         if trust_model:
             orgs = orgs.filter(trust_model=trust_model)
-        if is_ap:
-            orgs = orgs.filter(is_AP=is_ap)
-        if is_rp:
-            orgs = orgs.filter(is_RP=is_rp)
 
         paginator = LimitOffsetPagination()
         paginator.default_limit = 20

--- a/portal_backend/views/relying_party.py
+++ b/portal_backend/views/relying_party.py
@@ -19,7 +19,7 @@ from rest_framework import permissions
 from django.utils import timezone
 from django.db import transaction
 from ..dns_verification import generate_dns_challenge
-from .helpers import IsMaintainer, BelongsToOrganization
+from .helpers import IsMaintainerOrAdmin, BelongsToOrganization
 
 
 def check_existing_hostname(request):
@@ -52,7 +52,7 @@ class RelyingPartyRegisterAPIView(APIView):
     permission_classes = [
         permissions.IsAuthenticated,
         BelongsToOrganization,
-        IsMaintainer,
+        IsMaintainerOrAdmin,
     ]
 
     def make_condiscon_from_attributes(self, attributes_data):
@@ -313,7 +313,7 @@ class RelyingPartyHostnameStatusAPIView(APIView):
     permission_classes = [
         permissions.IsAuthenticated,
         BelongsToOrganization,
-        IsMaintainer,
+        IsMaintainerOrAdmin,
     ]
 
     @swagger_auto_schema(responses={200: "Success"})
@@ -339,7 +339,7 @@ class RelyingPartyRegistrationStatusAPIView(APIView):
     permission_classes = [
         permissions.IsAuthenticated,
         BelongsToOrganization,
-        IsMaintainer,
+        IsMaintainerOrAdmin,
     ]
 
     @swagger_auto_schema(responses={200: "Success"})

--- a/portal_frontend/src/models/auth_token.ts
+++ b/portal_frontend/src/models/auth_token.ts
@@ -1,4 +1,4 @@
-interface AuthToken {
+export interface AuthToken {
     token_type: "access" | "refresh"; // Assuming "access" and "refresh" as possible values
     exp: number; // Expiration time (Unix timestamp)
     iat: number; // Issued at time (Unix timestamp)

--- a/portal_frontend/src/models/auth_token.ts
+++ b/portal_frontend/src/models/auth_token.ts
@@ -1,0 +1,10 @@
+interface AuthToken {
+    token_type: "access" | "refresh"; // Assuming "access" and "refresh" as possible values
+    exp: number; // Expiration time (Unix timestamp)
+    iat: number; // Issued at time (Unix timestamp)
+    jti: string; // Unique identifier for the token
+    user_id: string; // User identifier (could be an email or a UUID)
+    email: string; // User email
+    role?: "admin" | "maintainer"; // User role (e.g., "user", "admin")
+    organizationId?: string; // Organization identifier
+}

--- a/portal_frontend/src/models/maintainer.ts
+++ b/portal_frontend/src/models/maintainer.ts
@@ -1,4 +1,4 @@
-interface Maintainer {
+export interface Maintainer {
     id: string;
     email: string;
     first_name: string;

--- a/portal_frontend/src/models/maintainer.ts
+++ b/portal_frontend/src/models/maintainer.ts
@@ -1,0 +1,6 @@
+interface Maintainer {
+    id: string;
+    email: string;
+    first_name: string;
+    last_name: string;
+}

--- a/portal_frontend/src/models/organization.ts
+++ b/portal_frontend/src/models/organization.ts
@@ -1,0 +1,17 @@
+interface Organization {
+    id: string;
+    name_en: string;
+    name_nl: string;
+    slug: string;
+    registration_number: string;
+    address: string;
+    is_verified: boolean;
+    verified_at: string | null;
+    trade_names: string[];
+    logo: string;
+    created_at: string;
+    last_updated_at: string;
+    is_RP: boolean;
+    is_AP: boolean;
+    trust_model: string;
+}

--- a/portal_frontend/src/models/organization.ts
+++ b/portal_frontend/src/models/organization.ts
@@ -1,4 +1,4 @@
-interface Organization {
+export interface Organization {
     id: string;
     name_en: string;
     name_nl: string;

--- a/portal_frontend/src/models/paginated-response.ts
+++ b/portal_frontend/src/models/paginated-response.ts
@@ -1,0 +1,6 @@
+interface PaginationResponse {
+    count: number;
+    next: string | null;
+    previous: string | null;
+    results: Organization[];
+}

--- a/portal_frontend/src/models/paginated-response.ts
+++ b/portal_frontend/src/models/paginated-response.ts
@@ -1,6 +1,6 @@
-interface PaginationResponse {
+interface PaginationResponse<T> {
     count: number;
     next: string | null;
     previous: string | null;
-    results: Organization[];
+    results: T[];
 }

--- a/portal_frontend/src/models/paginated-response.ts
+++ b/portal_frontend/src/models/paginated-response.ts
@@ -1,4 +1,4 @@
-interface PaginationResponse<T> {
+export interface PaginationResponse<T> {
     count: number;
     next: string | null;
     previous: string | null;

--- a/portal_frontend/src/models/relying-party.ts
+++ b/portal_frontend/src/models/relying-party.ts
@@ -1,4 +1,4 @@
-interface RelyingParty {
+export interface RelyingParty {
     id: number;
     yivi_tme: string;
     organization: string;

--- a/portal_frontend/src/models/relying-party.ts
+++ b/portal_frontend/src/models/relying-party.ts
@@ -1,0 +1,28 @@
+interface RelyingParty {
+    id: number;
+    yivi_tme: string;
+    organization: string;
+    status: string | null;
+    approved_rp_details: {
+      id: string;
+      logo: string;
+      hostnames: string[];
+      name: {
+        en: string;
+        nl: string;
+      };
+      scheme: string;
+    };
+    published_rp_details: {
+      id: string;
+      logo: string;
+      hostnames: string[];
+      name: {
+        en: string;
+        nl: string;
+      };
+      scheme: string;
+    };
+    created_at: string;
+    last_updated_at: string;
+  }

--- a/portal_frontend/src/pages/_app.tsx
+++ b/portal_frontend/src/pages/_app.tsx
@@ -1,10 +1,11 @@
 import type { AppProps } from "next/app";
 import { Geist, Geist_Mono } from "next/font/google";
 import "../styles/globals.css";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import useStore from "@/src/store";
+import { useRouter, useSearchParams } from 'next/navigation';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -17,6 +18,13 @@ const geistMono = Geist_Mono({
 });
 
 export default function MyApp({ Component, pageProps }: AppProps) {
+  const initializeAuth = useStore((state) => state.initializeAuth);
+  const router = useRouter();
+
+  useEffect(() => {
+    initializeAuth();
+  }, [initializeAuth]);
+
   const email = useStore((state) => state.email);
   const setAccessToken = useStore((state) => state.setAccessToken)
   const [isOpen, setIsOpen] = useState(false);
@@ -24,6 +32,8 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   const handleLogout = () => {
     setAccessToken(null);
     // Add any additional logout logic here
+    // Redirect to login page
+    router.push("/login");
   };
   return <div className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
     <header className="bg-white shadow-md">

--- a/portal_frontend/src/pages/_app.tsx
+++ b/portal_frontend/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import useStore from "@/src/store";
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/portal_frontend/src/pages/index.tsx
+++ b/portal_frontend/src/pages/index.tsx
@@ -6,7 +6,6 @@ import { Card, CardHeader, CardTitle, CardContent } from "../components/ui/card"
 import Link from "next/link";
 
 export default function Home() {
-  console.log(process.env.NEXT_PUBLIC_API_ENDPOINT);
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">

--- a/portal_frontend/src/pages/login/index.tsx
+++ b/portal_frontend/src/pages/login/index.tsx
@@ -34,7 +34,6 @@ export default function Login() {
       });
       web.start()
         .then((result: any) => {
-          console.log(result.access);
           setAccessToken(result.access);
           router.push('/organizations');
         })

--- a/portal_frontend/src/pages/login/index.tsx
+++ b/portal_frontend/src/pages/login/index.tsx
@@ -41,7 +41,7 @@ export default function Login() {
           alert(err);
         });
     });
-  }, [router, setAccessToken]);
+  }, [router, publicRuntimeConfig, setAccessToken]);
 
   return (
     <div className="flex justify-center items-center">

--- a/portal_frontend/src/pages/login/index.tsx
+++ b/portal_frontend/src/pages/login/index.tsx
@@ -8,7 +8,6 @@ import getConfig from "next/config";
 
 export default function Login() {
   const { publicRuntimeConfig } = getConfig();
-  const accessToken = useStore((state) => state.accessToken);
   const setAccessToken = useStore((state) => state.setAccessToken)
   const router = useRouter();
 
@@ -25,16 +24,6 @@ export default function Login() {
       
           start: {
             url: (o: any) => `${o.url}/session/`,
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              '@context': 'https://irma.app/ld/request/disclosure/v2',
-              'disclose': [
-                [
-                  ['pbdf.pbdf.email.email'],
-                  ['pbdf.sidn-pbdf.email.email'],
-                ]
-              ]
-            }),
             method: 'POST'
           },
           result: {
@@ -60,7 +49,6 @@ export default function Login() {
       <div className="flex grow p-6 justify-center items-center">
         <div id="yivi-web-form">
         </div>
-        {accessToken}
       </div>
     </div>
   );

--- a/portal_frontend/src/pages/organizations/[organizationId].tsx
+++ b/portal_frontend/src/pages/organizations/[organizationId].tsx
@@ -9,6 +9,9 @@ import Image from "next/image";
 import { axiosInstance } from '@/src/services/axiosInstance';
 import getConfig from 'next/config';
 import useStore from '@/src/store';
+import { Maintainer } from '@/src/models/maintainer';
+import { Organization } from '@/src/models/organization';
+import { RelyingParty } from '@/src/models/relying-party';
 
 export default function OrganizationPage() {
   const params = useParams();
@@ -54,7 +57,7 @@ export default function OrganizationPage() {
     if (organizationId) {
       fetchOrganizationData();
     }
-  }, [organizationId]);
+  }, [organizationId, userOrgId, userRole]);
   
   // Handler for section changes with data fetching
   const handleSectionChange = (section: string) => {

--- a/portal_frontend/src/pages/organizations/[organizationId].tsx
+++ b/portal_frontend/src/pages/organizations/[organizationId].tsx
@@ -8,9 +8,12 @@ import Link from 'next/link';
 import Image from "next/image";
 import { axiosInstance } from '@/src/services/axiosInstance';
 import getConfig from 'next/config';
+import useStore from '@/src/store';
 
 export default function OrganizationPage() {
   const params = useParams();
+  const userOrgId = useStore((state) => state.organizationId);
+  const userRole = useStore((state) => state.role);
   const organizationId = params?.organizationId;
 
   const { publicRuntimeConfig } = getConfig();
@@ -31,8 +34,10 @@ export default function OrganizationPage() {
         
         // Fetch maintainers
         try {
-          // const maintainersResponse = await axios.get(`/v1/organizations/${organizationId}/maintainers/`);
-          setMaintainers([]); //maintainersResponse.data
+          if ((userOrgId == organizationId && userRole == "maintainer") || userRole == "admin") {
+            const maintainersResponse = await axiosInstance.get<Maintainer[]>(`/v1/organizations/${organizationId}/maintainers/`);
+            setMaintainers(maintainersResponse.data);
+          }
         } catch (maintainersError) {
           console.error('Error fetching maintainers:', maintainersError);
           // Don't set error state, as this is not critical

--- a/portal_frontend/src/pages/organizations/[organizationId].tsx
+++ b/portal_frontend/src/pages/organizations/[organizationId].tsx
@@ -9,62 +9,6 @@ import Image from "next/image";
 import { axiosInstance } from '@/src/services/axiosInstance';
 import getConfig from 'next/config';
 
-// Define types
-interface Organization {
-  id: string;
-  name_en: string;
-  name_nl: string;
-  slug: string;
-  registration_number: string;
-  address: string;
-  is_verified: boolean;
-  verified_at: string | null;
-  trade_names: string[];
-  logo: string;
-  created_at: string;
-  last_updated_at: string;
-  is_RP: boolean;
-  is_AP: boolean;
-  trust_model: string;
-}
-
-interface Maintainer {
-  id: string;
-  email: string;
-  first_name: string;
-  last_name: string;
-}
-
-// New RP Details type based on the API response
-interface RPDetails {
-  id: number;
-  yivi_tme: string;
-  organization: string;
-  status: string | null;
-  approved_rp_details: {
-    id: string;
-    logo: string;
-    hostnames: string[];
-    name: {
-      en: string;
-      nl: string;
-    };
-    scheme: string;
-  };
-  published_rp_details: {
-    id: string;
-    logo: string;
-    hostnames: string[];
-    name: {
-      en: string;
-      nl: string;
-    };
-    scheme: string;
-  };
-  created_at: string;
-  last_updated_at: string;
-}
-
 export default function OrganizationPage() {
   const params = useParams();
   const organizationId = params?.organizationId;
@@ -72,7 +16,7 @@ export default function OrganizationPage() {
   const { publicRuntimeConfig } = getConfig();
   const [organization, setOrganization] = useState<Organization | null>(null);
   const [maintainers, setMaintainers] = useState<Maintainer[]>([]);
-  const [rpDetails, setRpDetails] = useState<RPDetails | null>(null);
+  const [rpDetails, setRpDetails] = useState<RelyingParty | null>(null);
   const [loadingRpDetails, setLoadingRpDetails] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -118,7 +62,7 @@ export default function OrganizationPage() {
         .then(response => {
           // Find the RP details for this organization
           const details = response.data.find(
-            (rp: RPDetails) => rp.organization === organization.name_en
+            (rp: RelyingParty) => rp.organization === organization.name_en
           );
           setRpDetails(details || null);
           setLoadingRpDetails(false);

--- a/portal_frontend/src/pages/organizations/index.tsx
+++ b/portal_frontend/src/pages/organizations/index.tsx
@@ -87,7 +87,6 @@ export default function OrganizationsPage() {
         newParams.delete(key);
       }
     });
-    console.log("New query params:", newParams.toString());
     router.push(`?${newParams.toString()}`);
   };
 
@@ -97,7 +96,6 @@ export default function OrganizationsPage() {
     const trustModel = searchParams.get("trust_model") || "all";
     const selectAPs = !searchParams.has("ap") || searchParams.get("ap") === "true";
     const selectRPs = !searchParams.has("rp") || searchParams.get("rp") === "true";
-    console.log("Initial query params:", search, trustModel, selectAPs, selectRPs, page);
     setSearchQuery(search);
     setSelectedTrustModel(trustModel);
     setAPSelected(selectAPs);
@@ -112,7 +110,6 @@ export default function OrganizationsPage() {
   const applyFilters = (searchQuery: string, selectedTrustModel: string, selectAPs: boolean, selectRPs: boolean) => {
     setApplyingFilters(true);
     setCurrentPage(1);
-    console.log("Applying filters:", searchQuery, selectedTrustModel, selectAPs, selectRPs);
     updateQueryParams({
       page: "1",
       search: searchQuery || undefined,
@@ -123,7 +120,6 @@ export default function OrganizationsPage() {
   };
 
   const handleFilterChange = (ap: boolean, rp: boolean, trustModel: string) => {
-    console.log("Filter change:", ap, rp, trustModel);
     applyFilters(searchQuery, trustModel, ap, rp);
   }
 

--- a/portal_frontend/src/pages/organizations/index.tsx
+++ b/portal_frontend/src/pages/organizations/index.tsx
@@ -10,6 +10,8 @@ import Image from "next/image";
 import { axiosInstance } from '@/src/services/axiosInstance';
 import getConfig from 'next/config';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { PaginationResponse } from '@/src/models/paginated-response';
+import { Organization } from '@/src/models/organization';
 
 export default function OrganizationsPage() {
   const { publicRuntimeConfig } = getConfig();
@@ -56,11 +58,10 @@ export default function OrganizationsPage() {
     axiosInstance.get<PaginationResponse<Organization>>(url)
       .then(response => {
         const data = response.data;
-        let orgs = data.results;
        
         setTotalCount(data.count);
         setTotalPages(Math.ceil(data.count / pageSize));
-        setOrganizations(orgs);
+        setOrganizations(data.results);
         
         // Extract trust models if not already done
         if (trustModels.length === 0) {

--- a/portal_frontend/src/pages/organizations/index.tsx
+++ b/portal_frontend/src/pages/organizations/index.tsx
@@ -36,7 +36,7 @@ export default function OrganizationsPage() {
   const fetchOrganizations = (page = 1, selectAPs: boolean, selectRPs: boolean) => {
     setLoading(true);
     const offset = (page - 1) * pageSize;
-    
+
     // Base URL with pagination
     let url = `/v1/organizations/?limit=${pageSize}&offset=${offset}`;
     
@@ -53,13 +53,13 @@ export default function OrganizationsPage() {
     url += `&rp=${selectRPs}`;
     url += `&ap=${selectAPs}`;
     
-    axiosInstance.get(url)
+    axiosInstance.get<PaginationResponse<Organization>>(url)
       .then(response => {
-        const data = response.data as PaginationResponse;
+        const data = response.data;
         let orgs = data.results;
        
-        setTotalCount(orgs.length);
-        setTotalPages(Math.ceil(orgs.length / pageSize));
+        setTotalCount(data.count);
+        setTotalPages(Math.ceil(data.count / pageSize));
         setOrganizations(orgs);
         
         // Extract trust models if not already done

--- a/portal_frontend/src/services/axiosInstance.ts
+++ b/portal_frontend/src/services/axiosInstance.ts
@@ -1,7 +1,22 @@
 import axios from 'axios';
 import getConfig from 'next/config';
+import useStore from '../store';
 const { publicRuntimeConfig } = getConfig();
 
 export const axiosInstance = axios.create({
   baseURL: publicRuntimeConfig.API_ENDPOINT,
 });
+
+axiosInstance.interceptors.request.use(
+  (config) => {
+    // Access token directly from Zustand store
+    const { accessToken } = useStore.getState();
+
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+
+    return config;
+  },
+  (error) => Promise.reject(error)
+);

--- a/portal_frontend/src/store/index.ts
+++ b/portal_frontend/src/store/index.ts
@@ -3,6 +3,7 @@
 import { create } from 'zustand'
 import { jwtDecode } from "jwt-decode";
 import { useEffect } from "react";
+import { AuthToken } from '../models/auth_token';
 
 interface StateStore {
     accessToken: string | null

--- a/portal_frontend/src/store/index.ts
+++ b/portal_frontend/src/store/index.ts
@@ -20,7 +20,6 @@ const useStore = create<StateStore>((set) => ({
     organizationId: undefined,
 
     setAccessToken: (newToken: string | null) => {
-        console.log(newToken);
         if (newToken) {
             const decoded = jwtDecode<AuthToken>(newToken);
             set({ email: decoded.email, role: decoded.role });

--- a/portal_frontend/src/store/index.ts
+++ b/portal_frontend/src/store/index.ts
@@ -4,46 +4,11 @@ import { create } from 'zustand'
 import { jwtDecode } from "jwt-decode";
 import { useEffect } from "react";
 
-export interface Organization {
-    id: string;
-    name_en: string;
-    name_nl: string;
-    slug: string;
-    registration_number: string;
-    address: string;
-    is_verified: boolean;
-    verified_at: string | null;
-    trade_names: string[];
-    logo: string;
-    created_at: string;
-    last_updated_at: string;
-    is_RP: boolean;
-    is_AP: boolean;
-    trust_model: string | null;
-}
-
-export interface PaninatedResult<T> {
-    count: number;
-    next: string | null;
-    previous: string | null;
-    results: T[];
-}
-
-interface AuthToken {
-    token_type: "access" | "refresh"; // Assuming "access" and "refresh" as possible values
-    exp: number; // Expiration time (Unix timestamp)
-    iat: number; // Issued at time (Unix timestamp)
-    jti: string; // Unique identifier for the token
-    user_id: string; // User identifier (could be an email or a UUID)
-    email: string; // User email
-    role: string; // User role (e.g., "user", "admin")
-    organizationId: string; // Organization identifier
-}
-
 interface StateStore {
     accessToken: string | null
     email: string | null
-    role: string | null
+    role?: "admin" | "maintainer";
+    organizationId?: string;
     setAccessToken: (accessToken: string | null) => void
     initializeAuth: () => void;
 }
@@ -51,36 +16,38 @@ interface StateStore {
 const useStore = create<StateStore>((set) => ({
     accessToken: null,
     email: null,
-    role: null,
+    role: undefined,
+    organizationId: undefined,
 
     setAccessToken: (newToken: string | null) => {
-        if (typeof window !== "undefined") { // ✅ Ensure this runs in the browser
-            console.log(newToken);
-            if (newToken) {
-                const decoded = jwtDecode<AuthToken>(newToken);
-                set({ email: decoded.email, role: decoded.role });
-                localStorage.setItem("accessToken", newToken);
-            } else {
-                set({ email: null, role: null });
-                localStorage.removeItem("accessToken");
-            }
-            set({ accessToken: newToken });
+        console.log(newToken);
+        if (newToken) {
+            const decoded = jwtDecode<AuthToken>(newToken);
+            set({ email: decoded.email, role: decoded.role });
+            localStorage.setItem("accessToken", newToken);
+        } else {
+            set({ email: null, role: undefined });
+            localStorage.removeItem("accessToken");
         }
+        set({ accessToken: newToken });
     },
 
     initializeAuth: () => {
-        if (typeof window !== "undefined") { // ✅ Ensure this runs in the browser
-            const savedAccessToken = localStorage.getItem("accessToken");
-            if (savedAccessToken) {
-                const decoded = jwtDecode<AuthToken>(savedAccessToken);
-                const currentTime = Math.floor(Date.now() / 1000);
-                
-                if (decoded.exp < currentTime) {
-                    localStorage.removeItem("accessToken");
-                    set({ accessToken: null, email: null, role: null });
-                } else {
-                    set({ accessToken: savedAccessToken, email: decoded.email, role: decoded.role });
-                }
+        const savedAccessToken = localStorage.getItem("accessToken");
+        if (savedAccessToken) {
+            const decoded = jwtDecode<AuthToken>(savedAccessToken);
+            const currentTime = Math.floor(Date.now() / 1000);
+
+            if (decoded.exp < currentTime) {
+                localStorage.removeItem("accessToken");
+                set({ accessToken: null, email: null, role: undefined });
+            } else {
+                set({
+                    accessToken: savedAccessToken,
+                    email: decoded.email,
+                    role: decoded.role,
+                    organizationId: decoded.organizationId
+                });
             }
         }
     },


### PR DESCRIPTION
Fixed the following:
- The session request for Yivi for logging in is constructed on the API side. 
- Logout redirects the user to the login page.
- The access token contains the `role` and `organizationId` claims of the user.
- The access token is used as a Bearer token for API calls.
- Maintainer API's check if for role `admin` or `maintainer` and organization id matches.
- Organization filtering is server side.
