### PR TITLE
Restructuring RP View

### DIFF
--- a/portal_backend/services/relying_party.py
+++ b/portal_backend/services/relying_party.py
@@ -1,0 +1,190 @@
+from typing import List, Dict, Any, Optional
+from django.shortcuts import get_object_or_404
+from django.utils import timezone
+from django.core.exceptions import ValidationError
+
+from ..models.models import (
+    Organization,
+    RelyingParty,
+    RelyingPartyHostname,
+    YiviTrustModelEnv,
+    Condiscon,
+    CondisconAttribute,
+    CredentialAttribute,
+)
+from ..dns_verification import generate_dns_challenge
+
+
+def create_relying_party(
+    data: Dict[str, Any], org_slug: str, rp_slug: str
+) -> RelyingParty:
+    organization = get_object_or_404(Organization, slug=org_slug)
+    yivi_tme = get_object_or_404(
+        YiviTrustModelEnv,
+        environment=data.get("environment"),
+        trust_model__name="yivi",
+    )
+    relying_party = RelyingParty(
+        rp_slug=rp_slug,
+        organization=organization,
+        yivi_tme=yivi_tme,
+        ready=False,
+        reviewed_accepted=None,
+        reviewed_at=None,
+        rejection_remarks=None,
+        published_at=None,
+    )
+    relying_party.full_clean()
+    relying_party.save()
+    return relying_party
+
+
+def check_duplicate_hostnames(
+    hostnames: List[str], current_rp: RelyingParty = None
+) -> None:
+    """
+    Raises ValidationError if any of the hostnames already exists in the database.
+    """
+    filtered = [h for h in hostnames if h]
+
+    same_entries = RelyingPartyHostname.objects.filter(hostname__in=filtered)
+
+    if same_entries.exists():
+        raise ValidationError(
+            {
+                "hostnames": [
+                    f"Hostname already exists: {h.hostname}" for h in same_entries
+                ]
+            }
+        )
+
+
+def parse_and_validate_hostnames(
+    hostnames: List[Dict[str, str]], current_rp: Optional[RelyingParty] = None
+) -> List[str]:
+    filtered = [h for h in hostnames if h]
+    new_hostnames = [
+        h.get("hostname") for h in filtered if isinstance(h, dict) and h.get("hostname")
+    ]
+    check_duplicate_hostnames(new_hostnames, current_rp=current_rp)
+    return new_hostnames
+
+
+def create_hostname_objects(
+    hostnames: List[str], relying_party: RelyingParty
+) -> List[RelyingPartyHostname]:
+    created = []
+    for hostname in hostnames:
+        obj = RelyingPartyHostname.objects.create(
+            relying_party=relying_party,
+            hostname=hostname,
+            dns_challenge=generate_dns_challenge(),
+            dns_challenge_created_at=timezone.now(),
+            dns_challenge_verified=False,
+        )
+        obj.full_clean()
+        obj.save()
+        created.append(obj)
+    return created
+
+
+def create_hostnames(
+    data: Dict[str, Any], relying_party: RelyingParty
+) -> List[RelyingPartyHostname]:
+    hostnames = data.get("hostnames", [])
+    new_hostnames = parse_and_validate_hostnames(hostnames)
+    return create_hostname_objects(new_hostnames, relying_party)
+
+
+def make_condiscon_json(
+    attributes_data: List[List[Dict[str, str]]],
+) -> List[List[List[str]]]:
+    condiscon_json = {
+        "@context": "https://irma.app/ld/request/disclosure/v2",
+        "disclose": [[]],
+    }
+    credential_attributes: Dict[str, List[str]] = {}
+    for attr in attributes_data:
+        cred_attr = get_object_or_404(
+            CredentialAttribute, name=attr["credential_attribute_name"]
+        )
+        cred_id = cred_attr.credential.id
+        credential_attributes.setdefault(cred_id, []).append(cred_attr.name)
+
+    for attr_list in credential_attributes.values():
+        condiscon_json["disclose"][0].append(attr_list)
+    return condiscon_json
+
+
+def create_condiscon(data: Dict[str, str], relying_party: RelyingParty) -> Condiscon:
+    condiscon_json = make_condiscon_json(data.get("attributes", []))
+    condiscon = Condiscon.objects.create(
+        condiscon=condiscon_json,
+        relying_party=relying_party,
+        context_description_en=data.get("context_description_en"),
+        context_description_nl=data.get("context_description_nl"),
+    )
+    return condiscon
+
+
+def create_condiscon_attributes(
+    condiscon: Condiscon,
+    attributes_data: List[
+        Dict[str, str]
+    ],  # TODO: maybe it would be nicer to create a type model for this
+) -> None:
+    for attr in attributes_data:
+        cred_attr = get_object_or_404(
+            CredentialAttribute, name=attr["credential_attribute_name"]
+        )
+        CondisconAttribute.objects.create(
+            credential_attribute=cred_attr,
+            condiscon=condiscon,
+            reason_en=attr["reason_en"],
+            reason_nl=attr["reason_nl"],
+        )
+
+
+def update_relying_party_hostnames(
+    relying_party: RelyingParty,
+    hostnames: List[Dict[str, str]],
+    response_data: Dict[str, str],
+) -> None:
+    new_hostnames = parse_and_validate_hostnames(hostnames, current_rp=relying_party)
+
+    RelyingPartyHostname.objects.filter(relying_party=relying_party).delete()
+    created = create_hostname_objects(new_hostnames, relying_party)
+
+    response_data["hostnames"] = [
+        {"hostname": h.hostname, "dns_challenge": h.dns_challenge} for h in created
+    ]
+
+
+def update_condiscon_attributes(
+    condiscon: Condiscon, attributes_data: List[Dict[str, str]]
+) -> None:
+    CondisconAttribute.objects.filter(condiscon=condiscon).delete()
+    create_condiscon_attributes(condiscon, attributes_data)
+
+
+def update_condiscon_context(condiscon: Condiscon, data: Dict[str, Any]) -> None:
+    if "context_description_en" in data:
+        condiscon.context_description_en = data["context_description_en"]
+    if "context_description_nl" in data:
+        condiscon.context_description_nl = data["context_description_nl"]
+    condiscon.save()
+
+
+def update_rp_environment(relying_party: RelyingParty, environment: str) -> None:
+    yivi_tme = get_object_or_404(YiviTrustModelEnv, environment=environment)
+    relying_party.yivi_tme = yivi_tme
+    relying_party.save()
+
+
+def update_rp_slug(
+    relying_party: RelyingParty, new_slug: str, response_data: Dict[str, Any]
+) -> None:
+    if new_slug != relying_party.rp_slug:
+        relying_party.rp_slug = new_slug
+        relying_party.save()
+        response_data["rp_slug"] = relying_party.rp_slug

--- a/portal_backend/services/relying_party.py
+++ b/portal_backend/services/relying_party.py
@@ -130,7 +130,6 @@ def make_condiscon_json(
 def create_condiscon(
     data: RelyingPartyResponse, relying_party: RelyingParty
 ) -> Condiscon:
-    print(f"data: {data}")
 
     condiscon_json = make_condiscon_json(data.get("attributes", []))
     condiscon = Condiscon.objects.create(

--- a/portal_backend/services/relying_party.py
+++ b/portal_backend/services/relying_party.py
@@ -96,14 +96,17 @@ def create_hostnames(
     return create_hostname_objects(new_hostnames, relying_party)
 
 
+# TODO: right now we are making a condiscon with OR for each credential type, we will need a more advanced
+# condiscon maker that can handle full possibilities of the condiscon supported by the frontend
 def make_condiscon_json(
-    attributes_data: List[List[Dict[str, str]]],
-) -> List[List[List[str]]]:
+    attributes_data: List[Dict[str, str]],
+) -> Dict[str, List[List[List[str]]]]:
     condiscon_json = {
         "@context": "https://irma.app/ld/request/disclosure/v2",
-        "disclose": [[]],
+        "disclose": [],
     }
     credential_attributes: Dict[str, List[str]] = {}
+
     for attr in attributes_data:
         cred_attr = get_object_or_404(
             CredentialAttribute, name=attr["credential_attribute_name"]
@@ -112,7 +115,8 @@ def make_condiscon_json(
         credential_attributes.setdefault(cred_id, []).append(cred_attr.name)
 
     for attr_list in credential_attributes.values():
-        condiscon_json["disclose"][0].append(attr_list)
+        condiscon_json["disclose"].append([attr_list])
+
     return condiscon_json
 
 

--- a/portal_backend/services/relying_party.py
+++ b/portal_backend/services/relying_party.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Optional
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.core.exceptions import ValidationError
@@ -16,7 +16,7 @@ from ..dns_verification import generate_dns_challenge
 
 
 def create_relying_party(
-    data: Dict[str, Any], org_slug: str, rp_slug: str
+    data: dict[str, list[dict[str, str]] | str], org_slug: str, rp_slug: str
 ) -> RelyingParty:
     organization = get_object_or_404(Organization, slug=org_slug)
     yivi_tme = get_object_or_404(
@@ -89,7 +89,7 @@ def create_hostname_objects(
 
 
 def create_hostnames(
-    data: Dict[str, Any], relying_party: RelyingParty
+    data: dict[str, str | list[dict[str, str]]], relying_party: RelyingParty
 ) -> List[RelyingPartyHostname]:
     hostnames = data.get("hostnames", [])
     new_hostnames = parse_and_validate_hostnames(hostnames)
@@ -116,7 +116,9 @@ def make_condiscon_json(
     return condiscon_json
 
 
-def create_condiscon(data: Dict[str, str], relying_party: RelyingParty) -> Condiscon:
+def create_condiscon(
+    data: dict[str, str | list[dict[str, str]]], relying_party: RelyingParty
+) -> Condiscon:
     condiscon_json = make_condiscon_json(data.get("attributes", []))
     condiscon = Condiscon.objects.create(
         condiscon=condiscon_json,
@@ -167,7 +169,9 @@ def update_condiscon_attributes(
     create_condiscon_attributes(condiscon, attributes_data)
 
 
-def update_condiscon_context(condiscon: Condiscon, data: Dict[str, Any]) -> None:
+def update_condiscon_context(
+    condiscon: Condiscon, data: dict[str, str | list[dict[str, str]]]
+) -> None:
     if "context_description_en" in data:
         condiscon.context_description_en = data["context_description_en"]
     if "context_description_nl" in data:
@@ -182,7 +186,9 @@ def update_rp_environment(relying_party: RelyingParty, environment: str) -> None
 
 
 def update_rp_slug(
-    relying_party: RelyingParty, new_slug: str, response_data: Dict[str, Any]
+    relying_party: RelyingParty,
+    new_slug: str,
+    response_data: Dict[str, str | list[dict[str, str]]],
 ) -> None:
     if new_slug != relying_party.rp_slug:
         relying_party.rp_slug = new_slug

--- a/portal_backend/services/relying_party.py
+++ b/portal_backend/services/relying_party.py
@@ -67,13 +67,13 @@ def check_duplicate_hostnames(
 
 
 def parse_and_validate_hostnames(
-    hostnames: HostnameEntry, current_rp: RelyingParty
+    hostnames: HostnameEntry,
 ) -> List[str]:
     filtered = [h for h in hostnames if h]
     new_hostnames = [
         h.get("hostname") for h in filtered if isinstance(h, dict) and h.get("hostname")
     ]
-    check_duplicate_hostnames(new_hostnames, current_rp=current_rp)
+    check_duplicate_hostnames(new_hostnames)
     return new_hostnames
 
 
@@ -127,9 +127,6 @@ def make_condiscon_json(
     return condiscon_json
 
 
-# data: {'rp_slug': 'test-rp5', 'environment': 'demo', 'context_description_en': 'dfx', 'context_description_nl': 'fds',
-# 'hostnames': ['verifier.example.nl'], 'attributes':
-# [{'credential_attribute_name': 'pbdf.pbdf.email.email', 'reason_en': 'something new now', 'reason_nl': ' te sturen'}]}
 def create_condiscon(
     data: RelyingPartyResponse, relying_party: RelyingParty
 ) -> Condiscon:
@@ -147,9 +144,7 @@ def create_condiscon(
 
 def create_condiscon_attributes(
     condiscon: Condiscon,
-    attributes_data: List[
-        AttributeEntry
-    ],  # TODO: maybe it would be nicer to create a type model for this
+    attributes_data: List[AttributeEntry],
 ) -> None:
     for attr in attributes_data:
         cred_attr = get_object_or_404(
@@ -168,7 +163,7 @@ def update_relying_party_hostnames(
     hostnames: List[HostnameEntry],
     response: Dict[str, str],
 ) -> None:
-    new_hostnames = parse_and_validate_hostnames(hostnames, current_rp=relying_party)
+    new_hostnames = parse_and_validate_hostnames(hostnames)
 
     RelyingPartyHostname.objects.filter(relying_party=relying_party).delete()
     created = create_hostname_objects(new_hostnames, relying_party)

--- a/portal_backend/swagger_specs/relying_party.py
+++ b/portal_backend/swagger_specs/relying_party.py
@@ -1,0 +1,152 @@
+from drf_yasg import openapi  # type: ignore
+from drf_yasg.utils import swagger_auto_schema  # type: ignore
+
+relying_party_create_schema = swagger_auto_schema(
+    responses={
+        201: "Created",
+        404: "Not Found",
+        400: "Bad Request",
+        401: "Unauthorized",
+    },
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        required=[
+            "hostname",
+            "environment",
+            "attributes",
+            "context_description_en",
+            "context_description_nl",
+        ],
+        properties={
+            "hostnames": openapi.Schema(
+                type=openapi.TYPE_ARRAY,
+                items=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={"hostname": openapi.Schema(type=openapi.TYPE_STRING)},
+                    required=["hostname"],
+                ),
+            ),
+            "environment": openapi.Schema(type=openapi.TYPE_STRING),
+            "context_description_en": openapi.Schema(type=openapi.TYPE_STRING),
+            "context_description_nl": openapi.Schema(type=openapi.TYPE_STRING),
+            "attributes": openapi.Schema(
+                type=openapi.TYPE_ARRAY,
+                items=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "credential_attribute_name": openapi.Schema(
+                            type=openapi.TYPE_STRING
+                        ),
+                        "reason_en": openapi.Schema(type=openapi.TYPE_STRING),
+                        "reason_nl": openapi.Schema(type=openapi.TYPE_STRING),
+                    },
+                ),
+            ),
+        },
+    ),
+)
+
+relying_party_patch_schema = swagger_auto_schema(
+    responses={
+        200: "Success",
+        404: "Not Found",
+        400: "Bad Request",
+        401: "Unauthorized",
+    },
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            "hostnames": openapi.Schema(
+                type=openapi.TYPE_ARRAY,
+                items=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={"hostname": openapi.Schema(type=openapi.TYPE_STRING)},
+                    required=["hostname"],
+                ),
+            ),
+            "environment": openapi.Schema(type=openapi.TYPE_STRING),
+            "context_description_en": openapi.Schema(type=openapi.TYPE_STRING),
+            "context_description_nl": openapi.Schema(type=openapi.TYPE_STRING),
+            "attributes": openapi.Schema(
+                type=openapi.TYPE_ARRAY,
+                items=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "credential_attribute_name": openapi.Schema(
+                            type=openapi.TYPE_STRING
+                        ),
+                        "reason_en": openapi.Schema(type=openapi.TYPE_STRING),
+                        "reason_nl": openapi.Schema(type=openapi.TYPE_STRING),
+                    },
+                ),
+            ),
+            "ready": openapi.Schema(type=openapi.TYPE_BOOLEAN),
+        },
+    ),
+)
+
+relying_party_delete_schema = swagger_auto_schema(
+    responses={
+        204: "No Content",
+        404: "Not Found",
+        403: "Forbidden",
+    }
+)
+
+relying_party_dns_status_schema = swagger_auto_schema(
+    responses={
+        200: "Success",
+        404: "Not Found",
+    }
+)
+
+relying_party_list_schema = swagger_auto_schema(
+    responses={
+        200: openapi.Response(
+            description="List of relying parties",
+            schema=openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "relying_parties": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_OBJECT,
+                            properties={
+                                "rp_slug": openapi.Schema(type=openapi.TYPE_STRING),
+                                "environment": openapi.Schema(type=openapi.TYPE_STRING),
+                            },
+                        ),
+                    )
+                },
+            ),
+        )
+    }
+)
+
+relying_party_detail_schema = swagger_auto_schema(
+    responses={
+        200: openapi.Response(
+            description="Detailed RP info",
+            schema=openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "rp_slug": openapi.Schema(type=openapi.TYPE_STRING),
+                    "hostnames": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Items(type=openapi.TYPE_OBJECT),
+                    ),
+                    "context_description_en": openapi.Schema(type=openapi.TYPE_STRING),
+                    "context_description_nl": openapi.Schema(type=openapi.TYPE_STRING),
+                    "attributes": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Items(type=openapi.TYPE_OBJECT),
+                    ),
+                    "environment": openapi.Schema(type=openapi.TYPE_STRING),
+                    "published_at": openapi.Schema(
+                        type=openapi.TYPE_STRING, format=openapi.FORMAT_DATETIME
+                    ),
+                },
+            ),
+        )
+    }
+)

--- a/portal_backend/swagger_specs/relying_party.py
+++ b/portal_backend/swagger_specs/relying_party.py
@@ -11,7 +11,7 @@ relying_party_create_schema = swagger_auto_schema(
     request_body=openapi.Schema(
         type=openapi.TYPE_OBJECT,
         required=[
-            "hostname",
+            "hostnames",
             "environment",
             "attributes",
             "context_description_en",
@@ -80,6 +80,7 @@ relying_party_patch_schema = swagger_auto_schema(
                     },
                 ),
             ),
+            "rp_slug": openapi.Schema(type=openapi.TYPE_STRING),
             "ready": openapi.Schema(type=openapi.TYPE_BOOLEAN),
         },
     ),

--- a/portal_backend/types.py
+++ b/portal_backend/types.py
@@ -1,0 +1,43 @@
+from typing import TypedDict, List, Union
+
+
+class HostnameEntry(TypedDict):
+    hostname: str
+    dns_challenge: str
+
+
+class AttributeEntry(TypedDict):
+    credential_attribute_name: str
+    reason_en: str
+    reason_nl: str
+
+
+class RelyingPartyBaseResponse(TypedDict):
+    hostnames: List[HostnameEntry]
+    environment: str
+    attributes: List[AttributeEntry]
+    context_description_en: str
+    context_description_nl: str
+
+
+class RelyingPartyUpdateResponse(RelyingPartyBaseResponse):
+    new_rp_slug: str
+    ready: bool
+
+
+class RelyingPartyCreateResponse(RelyingPartyBaseResponse):
+    rp_slug: str
+
+
+RelyingPartyResponse = Union[RelyingPartyCreateResponse, RelyingPartyUpdateResponse]
+
+
+AttributesList = List[str]
+
+
+class CondisconJSON(TypedDict):
+    disclose: List[List[AttributesList]]
+
+
+CredentialAttributeID = int
+CredentialAttributesEntry = dict[CredentialAttributeID, AttributesList]

--- a/portal_backend/urls.py
+++ b/portal_backend/urls.py
@@ -15,10 +15,13 @@ from portal_backend.views.attestation_provider import (
     AttestationProviderListView,
 )
 from portal_backend.views.relying_party import (
-    RelyingPartyDetailView,
     RelyingPartyHostnameStatusView,
     RelyingPartyUpdateView,
-    RelyingPartyListCreateView,
+    RelyingPartyListView,
+    RelyingPartyCreateView,
+    RelyingPartyUpdateView,
+    RelyingPartyRetrieveView,
+    RelyingPartyDeleteView,
 )
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view  # type: ignore
@@ -64,22 +67,31 @@ urlpatterns = [
         OrganizationMaintainerView.as_view(),
         name="organization-maintainers",
     ),
-
     # Relying Party
     path(
         "v1/yivi/organizations/<str:org_slug>/relying-party/",
-        RelyingPartyListCreateView.as_view(),
-        name="rp-list-create",
+        RelyingPartyListView.as_view(),
+        name="rp-list",
     ),
     path(
-        "v1/yivi/organizations/<str:org_slug>/relying-party/<str:environment>/<str:rp_slug>/",
-        RelyingPartyDetailView.as_view(),
-        name="single-rp-details",
+        "v1/yivi/organizations/<str:org_slug>/relying-party/create/",
+        RelyingPartyCreateView.as_view(),
+        name="rp-create",
     ),
     path(
         "v1/yivi/organizations/<str:org_slug>/relying-party/<str:rp_slug>/",
         RelyingPartyUpdateView.as_view(),
-        name="rp-manage",
+        name="rp-update",
+    ),
+    path(
+        "v1/yivi/organizations/<str:org_slug>/relying-party/<str:environment>/<str:rp_slug>/",
+        RelyingPartyRetrieveView.as_view(),
+        name="rp-detail",
+    ),
+    path(
+        "v1/yivi/organizations/<str:org_slug>/relying-party/<str:environment>/<str:rp_slug>/delete/",
+        RelyingPartyDeleteView.as_view(),
+        name="rp-delete",
     ),
     path(
         "v1/yivi/organizations/<str:org_slug>/relying-party/<str:environment>/<str:rp_slug>/dns-verification/",

--- a/portal_backend/urls.py
+++ b/portal_backend/urls.py
@@ -16,7 +16,6 @@ from portal_backend.views.attestation_provider import (
 )
 from portal_backend.views.relying_party import (
     RelyingPartyHostnameStatusView,
-    RelyingPartyUpdateView,
     RelyingPartyListView,
     RelyingPartyCreateView,
     RelyingPartyUpdateView,

--- a/portal_backend/views/relying_party.py
+++ b/portal_backend/views/relying_party.py
@@ -1,19 +1,31 @@
-from typing import Any, Dict, List, Optional, Union
-
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-from drf_yasg import openapi  # type: ignore
-from drf_yasg.utils import swagger_auto_schema  # type: ignore
 from rest_framework import permissions
-from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
+from ..services.relying_party import (
+    create_relying_party,
+    create_hostnames,
+    create_condiscon,
+    create_condiscon_attributes,
+    make_condiscon_json,
+    update_relying_party_hostnames,
+    update_condiscon_context,
+    update_condiscon_attributes,
+    update_rp_environment,
+    update_rp_slug,
+)
+from ..swagger_specs.relying_party import (
+    relying_party_create_schema,
+    relying_party_patch_schema,
+    relying_party_delete_schema,
+    relying_party_dns_status_schema,
+    relying_party_list_schema,
+)
 from .helpers import IsMaintainerOrAdmin, BelongsToOrganization
-from ..dns_verification import generate_dns_challenge
 from ..models.model_serializers import (
     CondisconSerializer,
     RelyingPartyHostnameSerializer,
@@ -21,251 +33,87 @@ from ..models.model_serializers import (
 from ..models.models import (
     RelyingParty,
     RelyingPartyHostname,
-    YiviTrustModelEnv,
     Organization,
     Condiscon,
     CondisconAttribute,
-    CredentialAttribute,
 )
 
 
-def check_existing_hostname(request: Request) -> Optional[Response]:
-    hostname_data = request.data.get("hostnames")
+class RelyingPartyCreateView(APIView):
+    permission_classes = [
+        permissions.IsAuthenticated,
+        BelongsToOrganization,
+        IsMaintainerOrAdmin,
+    ]
 
-    if not isinstance(hostname_data, list):
-        hostname_data = [hostname_data]
-
-        #  TODO: better check for existing hostnames
-
-
-class RelyingPartyListCreateView(APIView):
-
-    def get_permissions(self):
-        if self.request.method == "GET":
-            return [AllowAny()]
-        return [
-            IsAuthenticated(),
-            BelongsToOrganization(),
-            IsMaintainerOrAdmin(),
-        ]
-
-    def make_condiscon_from_attributes(
-        self, attributes_data: List[Dict[str, str]]
-    ) -> Dict[str, Any]:
-        condiscon_json = {
-            "@context": "https://irma.app/ld/request/disclosure/v2",
-            "disclose": [[]],
-        }
-
-        credential_attributes: Dict[int, List[str]] = {}
-
-        for attr in attributes_data:
-            credential_attribute = get_object_or_404(
-                CredentialAttribute,
-                name=attr["credential_attribute_name"],
-            )
-            credential_id = credential_attribute.credential.id
-
-            if credential_id not in credential_attributes:
-                credential_attributes[credential_id] = []
-
-            credential_attributes[credential_id].append(credential_attribute.name)
-
-        for credential_id, attribute_list in credential_attributes.items():
-            condiscon_json["disclose"][0].append(attribute_list)
-
-        return condiscon_json
-
-    def save_rp(self, request: Any, org_slug: str, rp_slug: str) -> RelyingParty:
-        yivi_tme = get_object_or_404(
-            YiviTrustModelEnv,
-            environment=request.data.get("environment"),
-            trust_model__name="yivi",
-        )
-        organization = get_object_or_404(Organization, slug=org_slug)
-        relying_party = RelyingParty(
-            yivi_tme=yivi_tme,
-            organization=organization,
-            rp_slug=rp_slug,
-        )
-        relying_party.full_clean()
-        relying_party.save()
-        return relying_party
-
-    def save_hostname(
-        self, request: Any, rp: RelyingParty
-    ) -> List[RelyingPartyHostname]:
-        hostname_text = request.data.get("hostnames")
-        if isinstance(hostname_text, list):
-            hostnames = []
-            for hostname in hostname_text:
-                hostname_obj, _ = RelyingPartyHostname.objects.get_or_create(
-                    relying_party=rp,
-                    hostname=hostname,
-                    defaults={
-                        "dns_challenge": generate_dns_challenge(),
-                        "dns_challenge_created_at": timezone.now(),
-                        "dns_challenge_verified": False,
-                    },
-                )
-                hostname_obj.full_clean()
-                hostname_obj.save()
-                hostnames.append(hostname_obj)
-            return hostnames
-        else:
-            hostname_obj, _ = RelyingPartyHostname.objects.get_or_create(
-                relying_party=rp,
-                hostname=hostname_text,
-                defaults={
-                    "dns_challenge": generate_dns_challenge(),
-                    "dns_challenge_created_at": timezone.now(),
-                    "dns_challenge_verified": False,
-                },
-            )
-            hostname_obj.full_clean()
-            hostname_obj.save()
-            return [hostname_obj]
-
-    def save_condiscon(
-        self, request: Request, attributes_data: List[Dict[str, str]], rp: RelyingParty
-    ) -> Condiscon:
-        condiscon_json = self.make_condiscon_from_attributes(attributes_data)
-        context_en = request.data.get("context_description_en")
-        context_nl = request.data.get("context_description_nl")
-        condiscon = Condiscon(
-            condiscon=condiscon_json,
-            context_description_en=context_en,
-            context_description_nl=context_nl,
-            relying_party=rp,
-        )
-        condiscon.full_clean()
-        condiscon.save()
-        return condiscon
-
-    def save_condiscon_attributes(
-        self, condiscon: Condiscon, attributes_data: List[Dict[str, str]]
-    ) -> None:
-        for attr_data in attributes_data:
-            credential_attribute = get_object_or_404(
-                CredentialAttribute,
-                name=attr_data["credential_attribute_name"],
-            )
-
-            condiscon_attr = CondisconAttribute(
-                credential_attribute=credential_attribute,
-                condiscon=condiscon,
-                reason_en=attr_data["reason_en"],
-                reason_nl=attr_data["reason_nl"],
-            )
-            condiscon_attr.full_clean()
-            condiscon_attr.save()
-
-    @swagger_auto_schema(
-        responses={
-            201: "Created",
-            404: "Not Found",
-            400: "Bad Request",
-            401: "Unauthorized",
-        },
-        request_body=openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            required=[
-                "hostname",
-                "environment",
-                "attributes",
-                "context_description_en",
-                "context_description_nl",
-            ],
-            properties={
-                "hostname": openapi.Schema(type=openapi.TYPE_STRING),
-                "environment": openapi.Schema(type=openapi.TYPE_STRING),
-                "context_description_en": openapi.Schema(type=openapi.TYPE_STRING),
-                "context_description_nl": openapi.Schema(type=openapi.TYPE_STRING),
-                "attributes": openapi.Schema(
-                    type=openapi.TYPE_ARRAY,
-                    items=openapi.Schema(
-                        type=openapi.TYPE_OBJECT,
-                        properties={
-                            "credential_attribute_id": openapi.Schema(
-                                type=openapi.TYPE_INTEGER
-                            ),
-                            "reason_en": openapi.Schema(type=openapi.TYPE_STRING),
-                            "reason_nl": openapi.Schema(type=openapi.TYPE_STRING),
-                        },
-                    ),
-                ),
-            },
-        ),
-    )
-    @transaction.atomic
+    @relying_party_create_schema
     def post(self, request: Request, org_slug: str) -> Response:
-        existing_hostname = check_existing_hostname(request)
-        if existing_hostname:
-            return existing_hostname
 
-        relying_party = self.save_rp(
-            request, org_slug, rp_slug=request.data.get("rp_slug")
+        relying_party = create_relying_party(
+            request.data, org_slug, request.data.get("rp_slug")
         )
-        relying_party.ready = False
-        relying_party.reviewed_accepted = None
-        relying_party.reviewed_at = None
-        relying_party.rejection_remarks = None
-        relying_party.published_at = None
-        relying_party.save()
-
-        hostnames = self.save_hostname(request, relying_party)
-        attributes_data = request.data.get("attributes", [])
-        condiscon = self.save_condiscon(request, attributes_data, relying_party)
-        self.save_condiscon_attributes(condiscon, attributes_data)
-
-        hostname_data = []
-        for hostname in hostnames:
-            hostname_data.append(
-                {"hostname": hostname.hostname, "dns_challenge": hostname.dns_challenge}
-            )
+        hostnames = create_hostnames(request.data, relying_party)
+        condiscon = create_condiscon(request.data, relying_party)
+        create_condiscon_attributes(condiscon, request.data.get("attributes", []))
 
         return Response(
             {
                 "slug": str(relying_party.rp_slug),
                 "message": "Relying party registration successful",
-                "hostnames": hostname_data,
+                "hostnames": [
+                    {"hostname": h.hostname, "dns_challenge": h.dns_challenge}
+                    for h in hostnames
+                ],
                 "current_status": {
                     "ready": relying_party.ready,
                     "reviewed_accepted": relying_party.reviewed_accepted,
                     "published_at": relying_party.published_at,
                 },
             },
-            status=status.HTTP_201_CREATED,
+            status=201,
         )
 
-    def get(self, request: Request, org_slug: str):
+
+class RelyingPartyListView(APIView):
+    permission_classes = [
+        permissions.IsAuthenticated,
+        BelongsToOrganization,
+        IsMaintainerOrAdmin,
+    ]
+
+    @relying_party_list_schema
+    def get(self, request: Request, org_slug: str) -> Response:
         organization = get_object_or_404(Organization, slug=org_slug)
         relying_parties = RelyingParty.objects.filter(organization=organization)
-        serialized = {
-            "relying_parties": [
-                {"rp_slug": rp.rp_slug, "environment": rp.yivi_tme.environment}
-                for rp in relying_parties
-            ]
-        }
+        return Response(
+            {
+                "relying_parties": [
+                    {"rp_slug": rp.rp_slug, "environment": rp.yivi_tme.environment}
+                    for rp in relying_parties
+                ]
+            }
+        )
 
-        return Response(serialized)
 
+class RelyingPartyRetrieveView(APIView):
+    permission_classes = [
+        permissions.IsAuthenticated,
+        BelongsToOrganization,
+        IsMaintainerOrAdmin,
+    ]
 
-class RelyingPartyDetailView(APIView):
-    permission_classes = [permissions.AllowAny]
-
-    def get(self, request, org_slug, environment, rp_slug):
+    def get(
+        self, request: Request, org_slug: str, environment: str, rp_slug: str
+    ) -> Response:
         relying_party = get_object_or_404(
             RelyingParty,
             organization__slug=org_slug,
             yivi_tme__environment=environment,
             rp_slug=rp_slug,
         )
-
         hostnames = RelyingPartyHostname.objects.filter(relying_party=relying_party)
-        hostnames_data = RelyingPartyHostnameSerializer(hostnames, many=True).data
-
-        condiscon = Condiscon.objects.filter(relying_party=relying_party).first()
+        condiscon = get_object_or_404(Condiscon, relying_party=relying_party)
+        attributes, context_description_en, context_description_nl = [], "", ""
 
         if condiscon:
             condiscon_data = CondisconSerializer(condiscon).data
@@ -282,46 +130,45 @@ class RelyingPartyDetailView(APIView):
             ]
             context_description_en = condiscon_data.get("context_description_en", "")
             context_description_nl = condiscon_data.get("context_description_nl", "")
-        else:
-            attributes = []
-            context_description_en = ""
-            context_description_nl = ""
 
-        serialized = {
-            "rp_slug": relying_party.rp_slug,
-            "hostnames": hostnames_data,
-            "context_description_en": context_description_en,
-            "context_description_nl": context_description_nl,
-            "attributes": attributes,
-            "environment": relying_party.yivi_tme.environment,
-            "published_at": relying_party.published_at,
-        }
-        return Response(serialized, status=status.HTTP_200_OK)
+        return Response(
+            {
+                "rp_slug": relying_party.rp_slug,
+                "hostnames": RelyingPartyHostnameSerializer(hostnames, many=True).data,
+                "context_description_en": context_description_en,
+                "context_description_nl": context_description_nl,
+                "attributes": attributes,
+                "environment": relying_party.yivi_tme.environment,
+                "published_at": relying_party.published_at,
+            }
+        )
 
-    @swagger_auto_schema(
-        responses={
-            204: "No Content",
-            404: "Not Found",
-            403: "Forbidden",
-        }
-    )
+
+class RelyingPartyDeleteView(APIView):
+    permission_classes = [
+        permissions.IsAuthenticated,
+        BelongsToOrganization,
+        IsMaintainerOrAdmin,
+    ]
+
+    @relying_party_delete_schema
     @transaction.atomic
-    def delete(self, request, environment, org_slug, rp_slug):
-        relying_party = get_object_or_404(
+    def delete(
+        self, request: Request, org_slug: str, environment: str, rp_slug: str
+    ) -> Response:
+        rp = get_object_or_404(
             RelyingParty,
             organization__slug=org_slug,
             rp_slug=rp_slug,
             yivi_tme__environment=environment,
         )
-
-        RelyingPartyHostname.objects.filter(relying_party=relying_party).delete()
-
-        condiscons = Condiscon.objects.filter(relying_party=relying_party)
-        for condiscon in condiscons:
-            CondisconAttribute.objects.filter(condiscon=condiscon).delete()
-        condiscons.delete()
-        relying_party.delete()
-
+        RelyingPartyHostname.objects.filter(
+            relying_party=rp
+        ).delete()  # TODO: we may wanna do this with signals in the future
+        condiscons = Condiscon.objects.filter(relying_party=rp)
+        for c in condiscons:
+            CondisconAttribute.objects.filter(condiscon=c).delete()
+        rp.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -332,226 +179,64 @@ class RelyingPartyUpdateView(APIView):
         IsMaintainerOrAdmin,
     ]
 
-    def save_updated_rp(
-        self,
-        request: Request,
-        relying_party: RelyingParty,
-        response_data: Dict[str, str],
-    ) -> Optional[Response]:
-        hostnames_raw = request.data.get("hostnames")
+    @relying_party_patch_schema
+    def patch(self, request: Request, org_slug: str, rp_slug: str) -> Response:
+        relying_party = get_object_or_404(
+            RelyingParty, organization__slug=org_slug, rp_slug=rp_slug
+        )
+        condiscon = get_object_or_404(Condiscon, relying_party=relying_party)
 
-        existing_hostname = check_existing_hostname(request)
-        if existing_hostname:
-            return existing_hostname
+        data = request.data
+        response_data = {"slug": str(relying_party.rp_slug)}
+        updated_fields = set()
 
-        # Normalize: extract `hostname` from each dict
-        if isinstance(hostnames_raw, list) and all(
-            isinstance(h, dict) and "hostname" in h for h in hostnames_raw
-        ):
-            hostname_values = [h["hostname"] for h in hostnames_raw]
-        elif isinstance(hostnames_raw, dict) and "hostname" in hostnames_raw:
-            hostname_values = [hostnames_raw["hostname"]]
-        elif isinstance(hostnames_raw, str):
-            hostname_values = [hostnames_raw]
-        else:
-            hostname_values = []
+        def update_context():
+            update_condiscon_context(condiscon, data)
+            updated_fields.add("context")
 
-        # Clear existing hostnames and create new ones
-        RelyingPartyHostname.objects.filter(relying_party=relying_party).delete()
+        def update_attributes():
+            update_condiscon_attributes(condiscon, data["attributes"])
+            condiscon.condiscon = make_condiscon_json(data["attributes"])
+            condiscon.save()
+            updated_fields.add("attributes")
 
-        hostnames: List[RelyingPartyHostname] = []
-        for hostname_text in hostname_values:
-            hostname_obj: RelyingPartyHostname = RelyingPartyHostname.objects.create(
-                relying_party=relying_party,
-                hostname=hostname_text,
-                dns_challenge=generate_dns_challenge(),
-                dns_challenge_created_at=timezone.now(),
-                dns_challenge_verified=False,
+        def update_hostnames():
+            update_relying_party_hostnames(
+                relying_party, data["hostnames"], response_data
             )
-            hostnames.append(hostname_obj)
+            updated_fields.add("hostnames")
 
-        response_data["hostnames"] = [
-            {"hostname": h.hostname, "dns_challenge": h.dns_challenge}
-            for h in hostnames
-        ]
-        response_data["message"] = "Relying party updated successfully"
-        return None  # Explicitly return None for clarity
+        def update_environment():
+            update_rp_environment(relying_party, data["environment"])
+            updated_fields.add("environment")
 
-    def save_updated_condiscon(
-        self, request: Request, condiscon: Condiscon, relying_party: RelyingParty
-    ) -> None:
-        if request.data.get("context_description_en") is not None:
-            condiscon.context_description_en = request.data.get(
-                "context_description_en"
-            )
-        if request.data.get("context_description_nl") is not None:
-            condiscon.context_description_nl = request.data.get(
-                "context_description_nl"
-            )
-        condiscon.save()
+        def update_slug():
+            update_rp_slug(relying_party, data["rp_slug"], response_data)
+            updated_fields.add("rp_slug")
 
-    def save_condiscon_attributes(
-        self, condiscon: Condiscon, attributes_data: List[Dict[str, str]]
-    ) -> None:
-        for attr_data in attributes_data:
-            credential_attribute = get_object_or_404(
-                CredentialAttribute,
-                name=attr_data["credential_attribute_name"],
-            )
-
-            condiscon_attr = CondisconAttribute(
-                credential_attribute=credential_attribute,
-                condiscon=condiscon,
-                reason_en=attr_data["reason_en"],
-                reason_nl=attr_data["reason_nl"],
-            )
-            condiscon_attr.full_clean()
-            condiscon_attr.save()
-
-    def make_condiscon_from_attributes(
-        self, attributes_data: List[Dict[str, str]]
-    ) -> Dict[str, Any]:
-        condiscon_json = {
-            "@context": "https://irma.app/ld/request/disclosure/v2",
-            "disclose": [[]],
+        dispatcher = {
+            ("context_description_en", "context_description_nl"): update_context,
+            ("attributes",): update_attributes,
+            ("hostnames",): update_hostnames,
+            ("environment",): update_environment,
+            ("rp_slug",): update_slug,
         }
 
-        credential_attributes: Dict[int, List[str]] = {}
+        for keys, handler in dispatcher.items():
+            if any(k in data for k in keys):
+                handler()
 
-        for attr in attributes_data:
-            credential_attribute = get_object_or_404(
-                CredentialAttribute,
-                name=attr["credential_attribute_name"],
-            )
-            credential_id = credential_attribute.credential.id
-
-            if credential_id not in credential_attributes:
-                credential_attributes[credential_id] = []
-
-            credential_attributes[credential_id].append(credential_attribute.name)
-
-        for credential_id, attribute_list in credential_attributes.items():
-            condiscon_json["disclose"][0].append(attribute_list)
-
-        return condiscon_json
-
-    @swagger_auto_schema(
-        responses={
-            200: "Success",
-            404: "Not Found",
-            400: "Bad Request",
-            401: "Unauthorized",
-        },
-        request_body=openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            properties={
-                "hostnames": openapi.Schema(
-                    type=openapi.TYPE_ARRAY,
-                    items=openapi.Schema(
-                        type=openapi.TYPE_OBJECT,
-                        properties={
-                            "hostname": openapi.Schema(type=openapi.TYPE_STRING)
-                        },
-                        required=["hostname"],
-                    ),
-                ),
-                "environment": openapi.Schema(type=openapi.TYPE_STRING),
-                "context_description_en": openapi.Schema(type=openapi.TYPE_STRING),
-                "context_description_nl": openapi.Schema(type=openapi.TYPE_STRING),
-                "attributes": openapi.Schema(
-                    type=openapi.TYPE_ARRAY,
-                    items=openapi.Schema(
-                        type=openapi.TYPE_OBJECT,
-                        properties={
-                            "credential_attribute_name": openapi.Schema(
-                                type=openapi.TYPE_STRING
-                            ),
-                            "reason_en": openapi.Schema(type=openapi.TYPE_STRING),
-                            "reason_nl": openapi.Schema(type=openapi.TYPE_STRING),
-                        },
-                    ),
-                ),
-                "ready": openapi.Schema(type=openapi.TYPE_BOOLEAN),
-            },
-        ),
-    )
-    def patch(self, request: Request, org_slug: str, rp_slug: str) -> Response:
-        environment: Optional[str] = request.data.get("environment")
-        # TODO: use environment to filter the relying party
-        relying_party: RelyingParty = get_object_or_404(
-            RelyingParty,
-            organization__slug=org_slug,
-            rp_slug=rp_slug,
-        )
-        condiscon: Condiscon = get_object_or_404(Condiscon, relying_party=relying_party)
-        response_message: str = "Relying party updated successfully"
-        response_data: Dict[str, str] = {"slug": str(relying_party.rp_slug)}
-
-        if (
-            request.data.get("context_description_en") is not None
-            or request.data.get("context_description_nl") is not None
-        ):
-            self.save_updated_condiscon(
-                request,
-                condiscon,
-                relying_party,
-            )
-
-        if request.data.get("attributes") is not None:
-            self.save_updated_attributes(
-                request,
-                condiscon,
-                relying_party,
-            )
-            attributes_data: List[Dict[str, str]] = request.data.get("attributes")
-            condiscon = get_object_or_404(Condiscon, relying_party=relying_party)
-            CondisconAttribute.objects.filter(condiscon=condiscon).delete()
-            self.save_condiscon_attributes(condiscon, attributes_data)
-            condiscon.condiscon = self.make_condiscon_from_attributes(attributes_data)
-            condiscon.save()
-
-        if request.data.get("hostnames") is not None:
-            self.save_updated_rp(
-                request,
-                relying_party,
-                response_data,
-            )
-
-        if request.data.get("environment") is not None:
-            yivi_tme: YiviTrustModelEnv = get_object_or_404(
-                YiviTrustModelEnv, environment=request.data.get("environment")
-            )
-            relying_party.yivi_tme = yivi_tme
-            relying_party.save()
-
-        if request.data.get("rp_slug") is not None:
-            new_slug = request.data.get("rp_slug")
-            if new_slug != relying_party.rp_slug:
-                relying_party.rp_slug = new_slug
-                relying_party.save()
-                response_data["rp_slug"] = relying_party.rp_slug
-                response_message += ". RP slug updated."
-
-        if "ready" in request.data:
-            relying_party.ready = request.data.get("ready")
+        if "ready" in data:
+            relying_party.ready = data["ready"]
             relying_party.ready_at = timezone.now() if relying_party.ready else None
             relying_party.reviewed_accepted = None
             relying_party.reviewed_at = None
             relying_party.rejection_remarks = None
-            relying_party.published_at = None
+            relying_party.published_at = (
+                None  # TODO: automatic public check not yet implemented
+            )
             relying_party.save()
-
-        # if any of these fields are updated, set ready to False. User must explicitly set ready to make status PENDING FOR REVIEW
-        elif any(
-            field in request.data
-            for field in [
-                "hostname",
-                "context_description_en",
-                "context_description_nl",
-                "attributes",
-                "environment",
-            ]
-        ):
+        elif updated_fields:
             relying_party.ready = False
             relying_party.ready_at = None
             relying_party.reviewed_accepted = None
@@ -560,24 +245,8 @@ class RelyingPartyUpdateView(APIView):
             relying_party.published_at = None
             relying_party.save()
 
-        response_data["message"] = response_message
-        return Response(response_data, status=status.HTTP_200_OK)
-
-
-class RelyingPartyListView(APIView):
-    permission_classes = [permissions.AllowAny]
-
-    def get(self, request: Request, org_slug: str):
-        organization = get_object_or_404(Organization, slug=org_slug)
-        relying_parties = RelyingParty.objects.filter(organization=organization)
-        serialized = {
-            "relying_parties": [
-                {"rp_slug": rp.rp_slug, "environment": rp.yivi_tme.environment}
-                for rp in relying_parties
-            ]
-        }
-
-        return Response(serialized)
+        response_data["message"] = "Relying party updated successfully"
+        return Response(response_data, status=200)
 
 
 class RelyingPartyHostnameStatusView(APIView):
@@ -587,7 +256,7 @@ class RelyingPartyHostnameStatusView(APIView):
         IsMaintainerOrAdmin,
     ]
 
-    @swagger_auto_schema(responses={200: "Success"})
+    @relying_party_dns_status_schema
     def get(
         self, request: Request, org_slug: str, environment: str, rp_slug: str
     ) -> Response:
@@ -604,13 +273,6 @@ class RelyingPartyHostnameStatusView(APIView):
         )
 
         return Response(
-            {
-                "hostname": hostname.hostname,
-                "dns_challenge": hostname.dns_challenge,
-                # hostname can be manually set as verified by admins in admin panel
-                "manually_verified": hostname.manually_verified,
-                "dns_challenge_verified": hostname.dns_challenge_verified,
-                "dns_challenge_verified_at": hostname.dns_challenge_verified_at,
-                "dns_challenge_invalidated_at": hostname.dns_challenge_invalidated_at,
-            }
+            {RelyingPartyHostnameSerializer(hostname).data},
+            status=status.HTTP_200_OK,
         )

--- a/portal_backend/views/relying_party.py
+++ b/portal_backend/views/relying_party.py
@@ -246,6 +246,7 @@ class RelyingPartyUpdateView(APIView):
             relying_party.save()
 
         response_data["message"] = "Relying party updated successfully"
+        print(f"response_data: {response_data}")
         return Response(response_data, status=200)
 
 

--- a/portal_backend/views/relying_party.py
+++ b/portal_backend/views/relying_party.py
@@ -246,7 +246,6 @@ class RelyingPartyUpdateView(APIView):
             relying_party.save()
 
         response_data["message"] = "Relying party updated successfully"
-        print(f"response_data: {response_data}")
         return Response(response_data, status=200)
 
 

--- a/portal_frontend/src/actions/manage-relying-party.ts
+++ b/portal_frontend/src/actions/manage-relying-party.ts
@@ -108,7 +108,7 @@ export async function registerRelyingParty(
       hostnames: data.hostnames.map((h) => h.hostname),
     };
     const response = await axiosInstance.post(
-      `/v1/yivi/organizations/${organizationSlug}/relying-party/`,
+      `/v1/yivi/organizations/${organizationSlug}/relying-party/create/`,
       payload
     );
     return { success: true, data: response.data };

--- a/portal_frontend/src/components/forms/relying-party/information.tsx
+++ b/portal_frontend/src/components/forms/relying-party/information.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import React from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { RelyingPartySchema, RelyingPartyFormData } from "./validation-schema";
@@ -41,7 +41,7 @@ type RelyingPartyProps =
     }
   | {
       isEditMode: false;
-      originalSlug?: never; // ✅ Enforce that it can't be passed
+      originalSlug?: never;
       defaultValues: RelyingPartyFormData;
       onSubmit: (data: RelyingPartyFormData) => void;
       serverErrors?: Partial<Record<keyof RelyingPartyFormData, string>>;
@@ -188,27 +188,44 @@ export default function RelyingPartyForm({
               }
             })}
           >
-            <FormField
-              control={control}
-              name="environment"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Environment</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
+            <div className="space-y-2 mt-4">
+              <FormField
+                control={control}
+                name="rp_slug"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Relying Party Slug</FormLabel>
                     <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select an environment" />
-                      </SelectTrigger>
+                      <Input {...field} />
                     </FormControl>
-                    <SelectContent>
-                      <SelectItem value="demo">Demo</SelectItem>
-                      <SelectItem value="production">Production</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage>{serverErrors.environment}</FormMessage>
-                </FormItem>
-              )}
-            />
+                    <FormMessage>{serverErrors.rp_slug}</FormMessage>
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="space-y-2 mt-4">
+              <FormField
+                control={control}
+                name="environment"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Environment</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select an environment" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="demo">Demo</SelectItem>
+                        <SelectItem value="production">Production</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
 
             <div className="space-y-2 mt-4">
               <FormLabel className="text-base font-medium">
@@ -252,7 +269,7 @@ export default function RelyingPartyForm({
                   <div key={field.id} className="flex gap-2 items-start">
                     <Input
                       {...register(`hostnames.${index}.hostname`)}
-                      defaultValue={field.hostname} // ✅ Use string directly
+                      defaultValue={field.hostname}
                       className="w-full"
                     />
                     <Button

--- a/portal_frontend/src/components/forms/relying-party/validation-schema.ts
+++ b/portal_frontend/src/components/forms/relying-party/validation-schema.ts
@@ -7,19 +7,34 @@ export const RelyingPartySchema = z.object({
     .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
       message: "Slug must be lowercase, hyphen-separated",
     }),
-  environment: z.string().min(1, "Environment is required"),
-  context_description_en: z.string().min(1),
-  context_description_nl: z.string().min(1),
+
+  environment: z.string().nonempty("Environment is required"),
+
+  context_description_en: z
+    .string()
+    .nonempty("English context description is required"),
+  context_description_nl: z
+    .string()
+    .nonempty("Dutch context description is required"),
+
   hostnames: z.array(
     z.object({
-      hostname: z.string().url(),
+      hostname: z
+        .string()
+        .regex(
+          /^(?!:\/\/)([a-zA-Z0-9-_]+\.)+[a-zA-Z]{2,}$/,
+          "Hostname must be a valid domain (e.g. example.com, sub.domain.dev)"
+        ),
     })
   ),
+
   attributes: z.array(
     z.object({
-      credential_attribute_name: z.string(),
-      reason_en: z.string(),
-      reason_nl: z.string(),
+      credential_attribute_name: z
+        .string()
+        .nonempty("Credential attribute name is required"),
+      reason_en: z.string().nonempty("English reason is required"),
+      reason_nl: z.string().nonempty("Dutch reason is required"),
     })
   ),
 });

--- a/portal_frontend/src/pages/organizations/[organization]/manage/relying-parties.tsx
+++ b/portal_frontend/src/pages/organizations/[organization]/manage/relying-parties.tsx
@@ -8,6 +8,7 @@ import { registerRelyingParty } from "@/src/actions/manage-relying-party";
 import ManageOrganizationLayout from "@/src/components/layout/manage-organization";
 import RelyingPartyList from "@/src/components/forms/relying-party/relying-party-list";
 import { Button } from "@/src/components/ui/button";
+import { toast } from "@/hooks/use-toast";
 
 const initialData: RelyingPartyFormData = {
   rp_slug: "",
@@ -53,10 +54,17 @@ export default function RelyingPartyManager() {
       setFieldErrors(result.fieldErrors || {});
       setGlobalError(result.globalError);
     } else {
-      alert("Saved!");
       setFieldErrors({});
       setGlobalError(undefined);
       setIsCreating(false);
+      toast({
+        title: "Relying Party Created",
+        description: "The relying party has been created successfully.",
+        variant: "default",
+      });
+      setTimeout(() => {
+        window.location.reload();
+      }, 2000);
     }
   };
 


### PR DESCRIPTION
This pull request introduces significant backend and frontend changes to enhance the management of Relying Parties (RPs) in the system. The backend now supports more granular operations for creating, updating, and deleting RPs, while the frontend includes improved form validation and UI updates for RP management. Swagger schemas for API documentation have also been added.

### Backend Enhancements

**Relying Party Management:**
* Added new utility functions in `portal_backend/services/relying_party.py` for creating, updating, and validating Relying Parties, hostnames, and condiscons. These include `create_relying_party`, `update_relying_party_hostnames`, and `create_condiscon` among others.

**API Documentation:**
* Introduced Swagger schemas in `portal_backend/swagger_specs/relying_party.py` for documenting endpoints related to Relying Party creation, updates, deletion, and retrieval.

**URL Restructuring:**
* Updated `portal_backend/urls.py` to split the Relying Party API endpoints into distinct views for list, create, retrieve, update, and delete operations. [[1]](diffhunk://#diff-a5b40cb5d42156b226c3c0ed01cad39ea0e500b864a6790484043005faef9db4L18-R23) [[2]](diffhunk://#diff-a5b40cb5d42156b226c3c0ed01cad39ea0e500b864a6790484043005faef9db4L67-R93)

### Frontend Improvements

**Form Enhancements:**
* Updated `RelyingPartyForm` in `portal_frontend/src/components/forms/relying-party/information.tsx` to include a new field for `rp_slug` and improved layout and error handling for environment and hostname fields. [[1]](diffhunk://#diff-8d7aa622377a8e53aa3fe2e9960b989546f8c4946edb1f992fa5edfe4746eea5R191-R206) [[2]](diffhunk://#diff-8d7aa622377a8e53aa3fe2e9960b989546f8c4946edb1f992fa5edfe4746eea5L208-R228) [[3]](diffhunk://#diff-8d7aa622377a8e53aa3fe2e9960b989546f8c4946edb1f992fa5edfe4746eea5L255-R272)

**Validation Updates:**
* Enhanced validation schema in `portal_frontend/src/components/forms/relying-party/validation-schema.ts` to enforce stricter rules for fields like `hostname`, `environment`, and `context_description`.

**API Endpoint Update:**
* Adjusted the API endpoint for registering a Relying Party in `portal_frontend/src/actions/manage-relying-party.ts` to align with the new backend structure.