### PR TITLE
bug-fix/relying-party

### DIFF
--- a/portal_backend/views/helpers.py
+++ b/portal_backend/views/helpers.py
@@ -38,7 +38,6 @@ class IsOrganizationMaintainerOrAdmin(permissions.BasePermission):
 
         token_org_slug: str | None = None
         if hasattr(request, "auth"):
-
             raw_token: AccessToken = str(request.auth)
             token = AccessToken(raw_token)
             token_org_slug = token.get("organizationSlug")
@@ -46,14 +45,8 @@ class IsOrganizationMaintainerOrAdmin(permissions.BasePermission):
         user_obj: User = get_object_or_404(User, email=request.user.email)
         if user_obj.role == "maintainer":
             if token_org_slug == request_org_slug:
-
                 return True
             else:
                 return False
         elif user_obj.role == "admin":
-            logger.info(
-                "User with email: "
-                + request.user.email
-                + " is admin and has access to all organizations"
-            )
             return True

--- a/portal_backend/views/helpers.py
+++ b/portal_backend/views/helpers.py
@@ -45,12 +45,6 @@ class IsOrganizationMaintainerOrAdmin(permissions.BasePermission):
 
         user_obj: User = get_object_or_404(User, email=request.user.email)
         if user_obj.role == "maintainer":
-            logger.info(
-                "organizationSlug from token: "
-                + token_org_slug
-                + " is maintainer to organization with slug: "
-                + str(request_org_slug)
-            )
             if token_org_slug == request_org_slug:
 
                 return True

--- a/portal_backend/views/organization.py
+++ b/portal_backend/views/organization.py
@@ -8,7 +8,7 @@ from ..models.model_serializers import MaintainerSerializer, OrganizationSeriali
 from ..models.models import AttestationProvider, Organization, RelyingParty
 from rest_framework import permissions
 from ..models.models import User
-from .helpers import BelongsToOrganization, IsMaintainerOrAdmin
+from .helpers import IsOrganizationMaintainerOrAdmin
 from rest_framework.pagination import LimitOffsetPagination
 from drf_yasg import openapi  # type: ignore
 from django.shortcuts import get_object_or_404
@@ -141,8 +141,7 @@ class OrganizationDetailView(APIView):
 class OrganizationMaintainersView(APIView):
     permission_classes = [
         permissions.IsAuthenticated,
-        BelongsToOrganization,
-        IsMaintainerOrAdmin,
+        IsOrganizationMaintainerOrAdmin,
     ]
 
     @swagger_auto_schema(responses={200: "Success"})
@@ -202,8 +201,7 @@ class OrganizationMaintainersView(APIView):
 class OrganizationMaintainerView(APIView):
     permission_classes = [
         permissions.IsAuthenticated,
-        BelongsToOrganization,
-        IsMaintainerOrAdmin,
+        IsOrganizationMaintainerOrAdmin,
     ]
 
     @swagger_auto_schema(

--- a/portal_backend/views/relying_party.py
+++ b/portal_backend/views/relying_party.py
@@ -25,7 +25,7 @@ from ..swagger_specs.relying_party import (
     relying_party_dns_status_schema,
     relying_party_list_schema,
 )
-from .helpers import IsMaintainerOrAdmin, BelongsToOrganization
+from .helpers import IsOrganizationMaintainerOrAdmin
 from ..models.model_serializers import (
     CondisconSerializer,
     RelyingPartyHostnameSerializer,
@@ -42,8 +42,7 @@ from ..models.models import (
 class RelyingPartyCreateView(APIView):
     permission_classes = [
         permissions.IsAuthenticated,
-        BelongsToOrganization,
-        IsMaintainerOrAdmin,
+        IsOrganizationMaintainerOrAdmin,
     ]
 
     @relying_party_create_schema
@@ -75,11 +74,7 @@ class RelyingPartyCreateView(APIView):
 
 
 class RelyingPartyListView(APIView):
-    permission_classes = [
-        permissions.IsAuthenticated,
-        BelongsToOrganization,
-        IsMaintainerOrAdmin,
-    ]
+    permission_classes = [permissions.AllowAny]
 
     @relying_party_list_schema
     def get(self, request: Request, org_slug: str) -> Response:
@@ -96,11 +91,7 @@ class RelyingPartyListView(APIView):
 
 
 class RelyingPartyRetrieveView(APIView):
-    permission_classes = [
-        permissions.IsAuthenticated,
-        BelongsToOrganization,
-        IsMaintainerOrAdmin,
-    ]
+    permission_classes = [permissions.AllowAny]
 
     def get(
         self, request: Request, org_slug: str, environment: str, rp_slug: str
@@ -112,7 +103,7 @@ class RelyingPartyRetrieveView(APIView):
             rp_slug=rp_slug,
         )
         hostnames = RelyingPartyHostname.objects.filter(relying_party=relying_party)
-        condiscon = get_object_or_404(Condiscon, relying_party=relying_party)
+        condiscon = Condiscon.objects.filter(relying_party=relying_party).first()
         attributes, context_description_en, context_description_nl = [], "", ""
 
         if condiscon:
@@ -147,8 +138,7 @@ class RelyingPartyRetrieveView(APIView):
 class RelyingPartyDeleteView(APIView):
     permission_classes = [
         permissions.IsAuthenticated,
-        BelongsToOrganization,
-        IsMaintainerOrAdmin,
+        IsOrganizationMaintainerOrAdmin,
     ]
 
     @relying_party_delete_schema
@@ -173,11 +163,7 @@ class RelyingPartyDeleteView(APIView):
 
 
 class RelyingPartyUpdateView(APIView):
-    permission_classes = [
-        permissions.IsAuthenticated,
-        BelongsToOrganization,
-        IsMaintainerOrAdmin,
-    ]
+    permission_classes = [permissions.IsAuthenticated, IsOrganizationMaintainerOrAdmin]
 
     @relying_party_patch_schema
     def patch(self, request: Request, org_slug: str, rp_slug: str) -> Response:
@@ -252,8 +238,7 @@ class RelyingPartyUpdateView(APIView):
 class RelyingPartyHostnameStatusView(APIView):
     permission_classes = [
         permissions.IsAuthenticated,
-        BelongsToOrganization,
-        IsMaintainerOrAdmin,
+        IsOrganizationMaintainerOrAdmin,
     ]
 
     @relying_party_dns_status_schema

--- a/portal_frontend/src/components/forms/relying-party/relying-party-list.tsx
+++ b/portal_frontend/src/components/forms/relying-party/relying-party-list.tsx
@@ -131,6 +131,7 @@ export default function RelyingPartyList() {
   return (
     <div>
       <div className="mb-6">
+        <div className="mb-3 font-semibold">Select Environment</div>
         <Select
           value={environment}
           onValueChange={(val) => setEnvironment(val)}

--- a/yivi_auth/views.py
+++ b/yivi_auth/views.py
@@ -24,11 +24,11 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
         logger.info("User with email: " + user.email + " logged in.")
         # # Add custom claims
         token["email"] = user.email
-        
+
         db_usr = User.objects.filter(email=user.email).first()
         if db_usr is not None:
-            token['role'] = db_usr.role
-            token['organizationId'] = str(db_usr.organization.id)
+            token["role"] = db_usr.role
+            token["organizationSlug"] = str(db_usr.organization.slug)
 
         return token
 
@@ -52,8 +52,11 @@ class YiviSessionProxyStartView(APIView):
         )
         try:
             session_request = {
-                "@context":"https://irma.app/ld/request/disclosure/v2",
-                "disclose":[[["pbdf.pbdf.email.email"],["pbdf.sidn-pbdf.email.email"]]]}
+                "@context": "https://irma.app/ld/request/disclosure/v2",
+                "disclose": [
+                    [["pbdf.pbdf.email.email"], ["pbdf.sidn-pbdf.email.email"]]
+                ],
+            }
             response = yivi_server.start_session(session_request)
         except YiviException as e:
             return Response(status=e.http_status, data=e.msg)
@@ -87,11 +90,9 @@ class YiviSessionProxyResultView(APIView):
 
             refresh = CustomTokenObtainPairSerializer.get_token(user)
             access_token = str(refresh.access_token)
-            response = Response(
-                {"access": access_token}, status=200
-            )
+            response = Response({"access": access_token}, status=200)
             # Cookie expires when refresh token does
-            refresh_lifetime = settings.SIMPLE_JWT['REFRESH_TOKEN_LIFETIME']
+            refresh_lifetime = settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"]
             expires_at = datetime.now(timezone.utc) + refresh_lifetime
             print(expires_at)
 
@@ -100,9 +101,9 @@ class YiviSessionProxyResultView(APIView):
                 value=str(refresh),
                 httponly=True,
                 secure=not settings.DEBUG,  # Set True in production
-                samesite="Lax",          # Or "Lax" depending on your app flow
+                samesite="Lax",  # Or "Lax" depending on your app flow
                 expires=expires_at,
-                path="/"
+                path="/",
             )
             return response
 


### PR DESCRIPTION
Adressed these comments: 
https://github.com/privacybydesign/yivi-portal/pull/35

- API calls like /v1/organizations/nijmegen/maintainers/ yields a 404 when the current user is not allowed to do anything. It should be a 401 not authorized.
- Manage -> Relying parties scheme selection should have a label. Scheme: Demo or production.
- GET yivi/organizations/nijmegen/relying-party/production/nijmegen/ returns a 404 no condiscon given.
(Rest of the issues in seperate PR.)

Later we will need proper access management, for example to not let user go to pages where they can't do any actions and will be denied from the API. In https://github.com/privacybydesign/yivi-portal/issues/38


