### PR TITLE
feat: Redirect unauthenticated users to the login page

### DIFF
--- a/portal_frontend/src/middleware.ts
+++ b/portal_frontend/src/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  // We can't access the access token, so we need to make due with the refresh token for now.
+  // If there's a better strategy for validating if a user is authenticated, feel free to change it. :)
+  if (!request.cookies.has("refresh_token")) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+
+    return NextResponse.redirect(url);
+  }
+}
+
+export const config = {
+  matcher: "/organizations/(.*)",
+};

--- a/portal_frontend/src/middleware.ts
+++ b/portal_frontend/src/middleware.ts
@@ -1,7 +1,10 @@
+import { RequestCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { AuthToken } from "./models/auth_token";
+import { jwtDecode } from "jwt-decode";
 
-export function middleware(request: NextRequest) {
+const isAuthenticated = (request: NextRequest): NextResponse | undefined => {
   // We can't access the access token, so we need to make due with the refresh token for now.
   // If there's a better strategy for validating if a user is authenticated, feel free to change it. :)
   if (!request.cookies.has("refresh_token")) {
@@ -10,6 +13,31 @@ export function middleware(request: NextRequest) {
 
     return NextResponse.redirect(url);
   }
+};
+
+const canManageOrganization = (
+  request: NextRequest,
+): NextResponse | undefined => {
+  const protectedRoute = "/manage";
+  const url = request.nextUrl.clone();
+  const token = request.cookies.get("refresh_token") as RequestCookie;
+  const organizationSlug = jwtDecode<AuthToken>(token.value).organizationSlug;
+
+  if (
+    url.pathname.endsWith(protectedRoute) &&
+    !url.pathname.includes(`/${organizationSlug}/`)
+  ) {
+    url.pathname = url.pathname.substring(
+      0,
+      url.pathname.length - protectedRoute.length,
+    );
+
+    return NextResponse.redirect(url);
+  }
+};
+
+export function middleware(request: NextRequest) {
+  return isAuthenticated(request) || canManageOrganization(request);
 }
 
 export const config = {

--- a/portal_frontend/src/pages/index.tsx
+++ b/portal_frontend/src/pages/index.tsx
@@ -58,7 +58,15 @@ export default function Home() {
               in the Yivi ecosystem.
               <div className="mt-4">
                 <Button variant="outline" asChild>
-                  <Link href={`/organizations/${organizationSlug}/manage`}>Manage organization</Link>
+                  <Link
+                    href={
+                      organizationSlug
+                        ? `/organizations/${organizationSlug}/manage`
+                        : "/login"
+                    }
+                  >
+                    Manage organization
+                  </Link>
                 </Button>
               </div>
             </CardContent>


### PR DESCRIPTION
Resolves #38

Would be nice to have some sort of redirect back to the protected route after logging in. Something like `/login?redirect=/organization/my-organization-name/manage` Thought it would be out of scope for #38, but it would a nice addition later on.
