### PR TITLE
chore: CI build workflow

### DIFF
--- a/.github/workflows/react-container.yml
+++ b/.github/workflows/react-container.yml
@@ -53,10 +53,9 @@ jobs:
 
       - name: Build container and push to GitHub Container Registry
         uses: docker/build-push-action@v5
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           context: portal_spa
           file: portal_spa/Dockerfile.react
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This change will always build the container, but prevent pushing it to the registry when triggered by a pull request.

I believe #90 is also aiming to fix this issue.