### PR TITLE
Issue demo credentials in the attribute-index

### DIFF
--- a/portal_spa/src/components/custom/attribute-index/CredentialAttributeDetails.tsx
+++ b/portal_spa/src/components/custom/attribute-index/CredentialAttributeDetails.tsx
@@ -1,0 +1,38 @@
+import { Input } from "@/components/ui/input";
+import type { CredentialAttribute } from "@/models/credential";
+
+type Props = {
+  attr: CredentialAttribute;
+  value?: string;
+  onChange?: (value: string) => void;
+  disabled?: boolean;
+};
+
+export function CredentialAttributeDetails({ attr, value, onChange }: Props) {
+  return (
+    <div className="border text-sm rounded-lg overflow-hidden">
+      <div className="overflow-x-auto p-4 space-y-1">
+        <div className="w-max">
+          <span className="font-mono font-bold">{attr.name_en}</span>
+          <span className="italic"> ({attr.credential_attribute_id})</span>
+        </div>
+        <div className="w-max">
+          <span className="font-medium">Identifier:</span>{" "}
+          <span className="font-mono">{attr.full_path}</span>
+        </div>
+        <div className="w-max">
+          <span className="font-medium">Description:</span>{" "}
+          {attr.description_en}
+        </div>
+        <div className="w-max pt-3">
+          <Input
+            id={`attribute-${attr.credential_attribute_id}`}
+            placeholder={attr.name_en}
+            value={value || ""}
+            onChange={(e) => onChange?.(e.target.value)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/portal_spa/src/components/custom/attribute-index/CredentialAttributesCard.tsx
+++ b/portal_spa/src/components/custom/attribute-index/CredentialAttributesCard.tsx
@@ -1,0 +1,36 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { CredentialAttributeDetails } from "./CredentialAttributeDetails";
+import { DemoCredentialForm } from "./DemoCredentialCard";
+import type { Credential } from "@/models/credential";
+
+type Props = {
+  credential: Credential;
+};
+
+export default function CredentialDetailsCard({ credential }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Attributes</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {credential.attributes.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            No attributes defined for this credential.
+          </p>
+        ) : credential.environment === "demo" ? (
+          <DemoCredentialForm credential={credential} />
+        ) : (
+          <div className="space-y-6">
+            {credential.attributes.map((attr) => (
+              <CredentialAttributeDetails
+                key={attr.credential_attribute_id}
+                attr={attr}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/portal_spa/src/components/custom/attribute-index/CredentialDetailsCard.tsx
+++ b/portal_spa/src/components/custom/attribute-index/CredentialDetailsCard.tsx
@@ -1,0 +1,90 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Link } from "react-router-dom";
+import type { Credential } from "@/models/credential";
+
+type Props = {
+  credential: Credential;
+};
+export default function CredentialDetailsCard({ credential }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Credential Details</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <dl className="space-y-3 text-sm">
+          <div>
+            <dt className="font-medium">Description</dt>
+            <dd>{credential.description_en}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Short Identifier</dt>
+            <dd>{credential.credential_id}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Identifier</dt>
+            <dd>{credential.full_path}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Organization</dt>
+            <dd>
+              <Link
+                to={`/organizations/${credential.org_slug}`}
+                className="text-blue-600"
+              >
+                {credential.org_name}
+              </Link>
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium">Attestation Provider</dt>
+            <dd>
+              <Link
+                to={`/attribute-index/attestation-provider/${credential.org_slug}/${credential.environment}/${credential.ap_slug}`}
+                className="text-blue-600"
+              >
+                {credential.ap_slug}
+              </Link>
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium">Environment</dt>
+            <dd>
+              <Link
+                to={`/attribute-index/environments/${credential.environment}`}
+                className="text-blue-600"
+              >
+                {credential.environment}
+              </Link>
+            </dd>
+          </div>
+          {credential.deprecated_since && (
+            <div>
+              <dt className="font-medium">Deprecated Since</dt>
+              <dd>{credential.deprecated_since}</dd>
+            </div>
+          )}
+          {credential.issue_url && (
+            <div>
+              <dt className="font-medium">Issue URL</dt>
+              <dd className="text-sm">
+                {credential.issue_url.startsWith("http") ? (
+                  <a
+                    href={credential.issue_url}
+                    className="text-blue-600 hover:underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {credential.issue_url}
+                  </a>
+                ) : (
+                  <span className="text-gray-500">{credential.issue_url}</span>
+                )}
+              </dd>
+            </div>
+          )}
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}

--- a/portal_spa/src/components/custom/attribute-index/DemoCredentialCard.tsx
+++ b/portal_spa/src/components/custom/attribute-index/DemoCredentialCard.tsx
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { axiosInstance } from "@/services/axiosInstance";
+import { CredentialAttributeDetails } from "./CredentialAttributeDetails";
+import type { Credential } from "@/models/credential";
+import { toast } from "sonner";
+
+type Props = {
+  credential: Credential;
+};
+
+export function DemoCredentialForm({ credential }: Props) {
+  const [attributeValues, setAttributeValues] = useState<{
+    [key: string]: string;
+  }>({});
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (id: string, value: string) => {
+    setAttributeValues((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const missing = credential.attributes.find(
+      (attr) => !attributeValues[attr.credential_attribute_id]?.trim()
+    );
+    if (missing) {
+      toast.error(`Please fill in: ${missing.name_en}`);
+      return;
+    }
+    try {
+      setLoading(true);
+      const yivi: any = await import("@privacybydesign/yivi-frontend");
+      const popup = yivi.newPopup({
+        debugging: import.meta.env.DEV,
+        language: "en",
+        translations: {
+          header:
+            'Issuing demo credential with <i class="yivi-web-logo">Yivi</i>',
+        },
+        session: {
+          url: axiosInstance.defaults.baseURL + "/v1",
+          start: {
+            url: (o: any) => `${o.url}/demo-issuance`,
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify({
+              credential: credential.full_path,
+              attributes: attributeValues,
+            }),
+          },
+          result: {
+            url: (o: any, { sessionToken }: any) =>
+              `${o.url}/demo-issuance/token/${sessionToken}`,
+            method: "GET",
+            credentials: "include",
+          },
+        },
+      });
+      await popup.start({});
+      toast.success("Demo credential issued successfully.");
+    } catch (e) {
+      toast.error(`Failed to issue demo credential. error: ${e}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {credential.attributes.map((attr) => (
+        <CredentialAttributeDetails
+          key={attr.credential_attribute_id}
+          attr={attr}
+          value={attributeValues[attr.credential_attribute_id] || ""}
+          onChange={(val) => handleChange(attr.credential_attribute_id, val)}
+        />
+      ))}
+      <Button type="submit" disabled={loading}>
+        {loading ? "Issuing..." : "Issue Demo Credential"}
+      </Button>
+    </form>
+  );
+}

--- a/portal_spa/src/pages/CredentialDetailsPage.tsx
+++ b/portal_spa/src/pages/CredentialDetailsPage.tsx
@@ -1,9 +1,11 @@
-import { Link, useOutletContext, useParams } from "react-router-dom";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useOutletContext, useParams } from "react-router-dom";
 import type { Credential } from "@/models/credential";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useEffect } from "react";
+import { Info } from "lucide-react";
+import CredentialDetailsCard from "@/components/custom/attribute-index/CredentialDetailsCard";
+import CredentialAttributesCard from "@/components/custom/attribute-index/CredentialAttributesCard";
 
 type OutletContext = {
   credentials: Credential[];
@@ -17,12 +19,12 @@ export default function CredentialDetailsPage() {
     (c) =>
       c.environment === environment &&
       c.ap_slug === ap_slug &&
-      c.credential_id === credential_id,
+      c.credential_id === credential_id
   );
 
   useEffect(
     () => window.scrollTo({ top: 0, behavior: "smooth" }),
-    [credential],
+    [credential]
   );
 
   if (!credentials?.length) {
@@ -40,6 +42,7 @@ export default function CredentialDetailsPage() {
 
   return (
     <div className="space-y-8">
+      {/* Header */}
       <h1 className="text-3xl font-semibold flex items-center gap-x-3">
         {credential.name_en}
         {credential.deprecated_since && (
@@ -47,129 +50,23 @@ export default function CredentialDetailsPage() {
         )}
       </h1>
 
-      {/* Credential Details */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Credential Details</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <dl className="space-y-3 text-sm">
-            <div>
-              <dt className="font-medium">Description</dt>
-              <dd>{credential.description_en}</dd>
-            </div>
-            <div>
-              <dt className="font-medium">Short Identifier</dt>
-              <dd>{credential.credential_id}</dd>
-            </div>
-            <div>
-              <dt className="font-medium">Identifier</dt>
-              <dd>{credential.full_path}</dd>
-            </div>
-            <div>
-              <dt className="font-medium">Organization</dt>
-              <dd>
-                <Link
-                  to={`/organizations/${credential.org_slug}`}
-                  className="text-blue-600"
-                >
-                  {credential.org_name}
-                </Link>
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium">Attestation Provider</dt>
-              <dd>
-                <Link
-                  to={`/attribute-index/attestation-provider/${credential.org_slug}/${credential.environment}/${credential.ap_slug}`}
-                  className="text-blue-600"
-                >
-                  {credential.ap_slug}
-                </Link>
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium">Environment</dt>
-              <dd>
-                <Link
-                  to={`/attribute-index/environments/${credential.environment}`}
-                  className="text-blue-600"
-                >
-                  {credential.environment}
-                </Link>
-              </dd>
-            </div>
-            {credential.deprecated_since && (
-              <div>
-                <dt className="font-medium">Deprecated Since</dt>
-                <dd>{credential.deprecated_since}</dd>
-              </div>
-            )}
-            {credential.issue_url && (
-              <div>
-                <dt className="font-medium">Issue URL</dt>
-                <dd className="text-sm">
-                  {credential.issue_url.startsWith("http") ? (
-                    <a
-                      href={credential.issue_url}
-                      className="text-blue-600 hover:underline"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {credential.issue_url}
-                    </a>
-                  ) : (
-                    <span className="text-gray-500">
-                      {credential.issue_url}
-                    </span>
-                  )}
-                </dd>
-              </div>
-            )}
-          </dl>
-        </CardContent>
+      {/* Demo info */}
+      {credential.environment === "demo" && (
+        <div className="flex items-center gap-x-2 rounded-md bg-yellow-50 p-4 text-yellow-800">
+          <Info className="h-8 w-8 mr-3" />
+          <span>
+            You can obtain this credential by filling out the attribute fields
+            below. This demo credential has no real value, other than to
+            demonstrate the experience of a Yivi credential issuance.
+          </span>
+        </div>
+      )}
 
-        {/* Attributes */}
-        <CardHeader>
-          <CardTitle className="text-lg">Attributes</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {credential.attributes.length === 0 ? (
-            <p className="text-sm text-gray-500">
-              No attributes defined for this credential.
-            </p>
-          ) : (
-            <div className="space-y-6">
-              {credential.attributes.map((attr) => (
-                <div
-                  className="border text-sm rounded-lg overflow-hidden"
-                  key={attr.credential_attribute_id}
-                >
-                  <div className="overflow-x-auto p-4 space-y-1">
-                    <div className="w-max">
-                      <span className="font-mono font-bold">
-                        {attr.name_en}
-                      </span>
-                      <span className="italic">
-                        {" "}
-                        ({attr.credential_attribute_id})
-                      </span>
-                    </div>
-                    <div className="w-max">
-                      <span className="font-medium">Identifier:</span>{" "}
-                      <span className="font-mono">{attr.full_path}</span>
-                    </div>
-                    <div className="w-max">
-                      <span className="font-medium">Description:</span>{" "}
-                      {attr.description_en}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      {/* Credential Details */}
+      <CredentialDetailsCard credential={credential} />
+
+      {/* Attributes */}
+      <CredentialAttributesCard credential={credential} />
     </div>
   );
 }

--- a/yivi_auth/urls.py
+++ b/yivi_auth/urls.py
@@ -6,7 +6,17 @@ app_name = "yivi_auth"
 
 urlpatterns = [
     path("v1/session/", views.YiviSessionProxyStartView.as_view(), name="start"),
-    path('v1/token/<str:yivi_token>', views.YiviSessionProxyResultView.as_view(), name='token_obtain_pair'),
-    path('v1/refreshtoken', views.RefreshTokenView.as_view(), name='token_refresh'),
-    path('v1/logout', views.LogoutView.as_view(), name='logout'),
+    path(
+        "v1/token/<str:yivi_token>",
+        views.YiviSessionProxyResultView.as_view(),
+        name="token_obtain_pair",
+    ),
+    path("v1/refreshtoken", views.RefreshTokenView.as_view(), name="token_refresh"),
+    path("v1/logout", views.LogoutView.as_view(), name="logout"),
+    path("v1/demo-issuance", views.YiviIssueDemosView.as_view(), name="demo_issuance"),
+    path(
+        "v1/demo-issuance/token/<str:yivi_token>",
+        views.YiviDemoIssuanceResultView.as_view(),
+        name="demo_issuance_token",
+    ),
 ]


### PR DESCRIPTION
### Frontend Changes

#### New Components for Credential Details and Attributes
* Added `CredentialDetailsCard` to display detailed information about a credential, including links to related entities like organizations and attestation providers. (`portal_spa/src/components/custom/attribute-index/CredentialDetailsCard.tsx`)
* Added `CredentialAttributesCard` to handle the display of credential attributes, with special handling for demo environments using the `DemoCredentialForm` component. (`portal_spa/src/components/custom/attribute-index/CredentialAttributesCard.tsx`)
* Created `CredentialAttributeDetails` to encapsulate the rendering of individual credential attributes, including editable fields for demo attributes. (`portal_spa/src/components/custom/attribute-index/CredentialAttributeDetails.tsx`)

#### Demo Credential Issuance Flow
* Introduced `DemoCredentialForm` to allow users to input attribute values and issue demo credentials via the Yivi server. This includes form validation, API interaction, and success/error handling using `toast`. (`portal_spa/src/components/custom/attribute-index/DemoCredentialCard.tsx`)

#### Refactoring of `CredentialDetailsPage`
* Replaced inline credential details and attributes rendering with the new `CredentialDetailsCard` and `CredentialAttributesCard` components for improved modularity. (`portal_spa/src/pages/CredentialDetailsPage.tsx`) [[1]](diffhunk://#diff-622479d004cda398ee277b8a29b7cd9418b6a47a750b198e623101e263e90c90L1-R8) [[2]](diffhunk://#diff-622479d004cda398ee277b8a29b7cd9418b6a47a750b198e623101e263e90c90R45-R69)

---

### Backend Changes

#### API Endpoints for Demo Credential Issuance
* Added a new endpoint `/v1/demo-issuance` to initiate a Yivi session for issuing demo credentials. (`yivi_auth/urls.py`, `yivi_auth/views.py`) [[1]](diffhunk://#diff-660bf5aaa439c07276c82599dd5c426b7eb028e58c027503d5d68f5d2bd3d119L9-R21) [[2]](diffhunk://#diff-93f4a70f169050c889b684482e7e674681b19698c964906a0dc4c68f0f86636dR15-R82)
* Added `/v1/demo-issuance/token/<str:yivi_token>` to retrieve the result of a demo issuance session. (`yivi_auth/urls.py`, `yivi_auth/views.py`) [[1]](diffhunk://#diff-660bf5aaa439c07276c82599dd5c426b7eb028e58c027503d5d68f5d2bd3d119L9-R21) [[2]](diffhunk://#diff-93f4a70f169050c889b684482e7e674681b19698c964906a0dc4c68f0f86636dR15-R82)

These changes provide a seamless way to issue demo credentials while improving the modularity and maintainability of the frontend code. The backend updates ensure secure and reliable handling of demo credential issuance through the Yivi server.