### PR TITLE
Make auth initialization async

### DIFF
--- a/portal_spa/src/components/forms/organization/child-components/SlugField.tsx
+++ b/portal_spa/src/components/forms/organization/child-components/SlugField.tsx
@@ -38,7 +38,7 @@ export default function SlugField({
             <FormControl>
               <Input
                 {...field}
-                pattern="[a-z0-9\-]+"
+                pattern="[a-zA-Z0-9\-]+"
                 onBlur={(event) => {
                   if (!event.target.value && form.getValues("name_en")) {
                     const newSlug = generateSlug(


### PR DESCRIPTION
Problem: 

The refresh token function was initially triggered only when requests to api came back with unauthorized. So if the user was idle on the page with no actions with protected pages such as register organization, they would see a black page because of the following part:

https://github.com/privacybydesign/yivi-portal/blob/e57992648babbc99cea397a95a4360fa7a3f8903/portal_spa/src/components/auth/ProtectedRoute.tsx#L21-L23

so I made initializeAuth which is in charge of setting this flag async
https://github.com/privacybydesign/yivi-portal/blob/e57992648babbc99cea397a95a4360fa7a3f8903/portal_spa/src/store/index.ts#L15-L16

And tried a few times and it seems to have resolved the issue

