### PR TITLE
Change admin path

### DIFF
--- a/yivi_portal/urls.py
+++ b/yivi_portal/urls.py
@@ -5,8 +5,11 @@ from django.urls import path, include
 from django.views.generic import RedirectView
 
 urlpatterns = [
-    path("admin/logout/", RedirectView.as_view(url="/logout", query_string=True)),
-    path("admin/", admin.site.urls),
+    path(
+        "yivi-admin/logout/",
+        RedirectView.as_view(url="/logout", query_string=True),
+    ),
+    path("yivi-admin/", admin.site.urls),
     path("", include("portal_backend.urls")),
     path("", include("yivi_auth.urls")),
     # Serve media files separately


### PR DESCRIPTION
We also need to have some IP restriction to limit access to this page. changing the default admin url will just help with bots, but a better security measure needs to be implemented.