### PR TITLE
Use latest Yivi frontend packages with universal links

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,8 @@ services:
       - 9000:5173
     depends_on:
       - django
+    environment:
+      - VITE_API_ENDPOINT=${VITE_API_ENDPOINT:-http://localhost:8000}
     volumes:
       - ./portal_spa:/app
       - /app/node_modules/ # This will exclude node_modules from syncing to the container and prevents a crash on a missing library when working on Mac.

--- a/portal_spa/package-lock.json
+++ b/portal_spa/package-lock.json
@@ -9,7 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
-        "@privacybydesign/yivi-frontend": "^0.2.1",
+        "@privacybydesign/yivi-client": "^1.0.0",
+        "@privacybydesign/yivi-core": "^1.0.0",
+        "@privacybydesign/yivi-css": "^1.0.1",
+        "@privacybydesign/yivi-popup": "^1.0.1",
+        "@privacybydesign/yivi-web": "^1.0.1",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-avatar": "^1.1.9",
         "@radix-ui/react-checkbox": "^1.3.1",
@@ -2202,11 +2206,53 @@
         "node": ">=12"
       }
     },
-    "node_modules/@privacybydesign/yivi-frontend": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-frontend/-/yivi-frontend-0.2.1.tgz",
-      "integrity": "sha512-v9Xv6YGIL7qxI4JkQqHfPs99tNC3TMlZHzQ8PLp3iw2fEoIZMQBBOvLMfDyiP9vBOI+aLVpdnM4cuJisHl1riA==",
+    "node_modules/@privacybydesign/yivi-client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0.tgz",
+      "integrity": "sha512-juWqDD2KCeytycw1AH07HqP6L3GFepHSQa3cyOwP2M8yCzsWml7nVSbAhyfUJnoblq91pcagEA6vVc1xf/5Njg==",
+      "license": "SEE LICENSE IN REPOSITORY",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "peerDependencies": {
+        "@privacybydesign/yivi-core": "1.0.0"
+      }
+    },
+    "node_modules/@privacybydesign/yivi-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0.tgz",
+      "integrity": "sha512-jPpx3eiKZTMfY0nCPNRMUupqQIVAP3Z0kOU3XBH8F7dsJIQFi4NJHf4X7+QdmFTgcogR0wSmEjFBoOv+nbq4KA==",
       "license": "SEE LICENSE IN REPOSITORY"
+    },
+    "node_modules/@privacybydesign/yivi-css": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.1.tgz",
+      "integrity": "sha512-4cN1cSrgmbm5+syhgFOMV0zW0jJMED1WD0vAGlYKrEhf4vMWIZCE0pwFjRwRDlR+Qgy6fNtgW27Qt8EyF0pkfg==",
+      "license": "SEE LICENSE IN REPOSITORY"
+    },
+    "node_modules/@privacybydesign/yivi-popup": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-popup/-/yivi-popup-1.0.1.tgz",
+      "integrity": "sha512-H2evzsDwRwu1lNNly3khHIQlqZP2qF02WuE2Q2UOyQLeBunwoDdh0IPEeZ/d9eXmSJVAuudhOheAiz1S9obC1w==",
+      "license": "SEE LICENSE IN REPOSITORY",
+      "dependencies": {
+        "@privacybydesign/yivi-core": "1.0.0",
+        "@privacybydesign/yivi-web": "1.0.1",
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "node_modules/@privacybydesign/yivi-web": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.1.tgz",
+      "integrity": "sha512-fyVzdmUG0ZNC5IIsU3+daq95EM06LgrJ5F/uLnqzzJZJNfy0p98dt6Gy/nzVPqd3tUAQK+lO5704kGXLO1qDTg==",
+      "license": "SEE LICENSE IN REPOSITORY",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "qrcode": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@privacybydesign/yivi-core": "1.0.0"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -5185,7 +5231,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -5196,8 +5241,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -5361,6 +5405,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
@@ -5389,6 +5442,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -5468,6 +5530,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -7555,6 +7623,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
@@ -7611,7 +7688,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7670,6 +7746,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -7790,6 +7875,186 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/qrcode/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -8078,6 +8343,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8085,6 +8359,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -8265,6 +8545,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
@@ -9258,6 +9544,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/portal_spa/package.json
+++ b/portal_spa/package.json
@@ -12,7 +12,11 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
-    "@privacybydesign/yivi-frontend": "^0.2.1",
+    "@privacybydesign/yivi-client": "^1.0.0",
+    "@privacybydesign/yivi-core": "^1.0.0",
+    "@privacybydesign/yivi-css": "^1.0.1",
+    "@privacybydesign/yivi-popup": "^1.0.1",
+    "@privacybydesign/yivi-web": "^1.0.1",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-avatar": "^1.1.9",
     "@radix-ui/react-checkbox": "^1.3.1",

--- a/portal_spa/src/components/custom/attribute-index/DemoCredentialCard.tsx
+++ b/portal_spa/src/components/custom/attribute-index/DemoCredentialCard.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { axiosInstance } from "@/services/axiosInstance";
+import { newPopup } from "@/services/yivi";
 import { CredentialAttributeDetails } from "./CredentialAttributeDetails";
 import type { Credential } from "@/models/credential";
 import { toast } from "sonner";
@@ -31,8 +32,7 @@ export function DemoCredentialCard({ credential }: Props) {
     }
     try {
       setLoading(true);
-      const yivi: any = await import("@privacybydesign/yivi-frontend");
-      const popup = yivi.newPopup({
+      const popup = newPopup({
         debugging: import.meta.env.DEV,
         language: "en",
         translations: {

--- a/portal_spa/src/pages/LoginPage.tsx
+++ b/portal_spa/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { apiEndpoint } from "@/services/axiosInstance";
+import { newWeb, type YiviSession } from "@/services/yivi";
 import useStore from "@/store";
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -10,39 +11,45 @@ export default function Login() {
   const location = useLocation();
 
   useEffect(() => {
-    let web: any;
-    import("@privacybydesign/yivi-frontend").then((yivi: any) => {
-      web = yivi.newWeb({
-        debugging: import.meta.env.DEV,
-        element: "#yivi-web-form",
-        language: "en",
-        session: {
-          url: apiEndpoint + "/v1",
-          start: {
-            url: (o: any) => `${o.url}/session/`,
-            method: "POST",
-            credentials: "include",
-          },
-          result: {
-            url: (o: any, { sessionToken }: any) =>
-              `${o.url}/token/${sessionToken}`,
-            method: "GET",
-            credentials: "include",
-          },
+    const web: YiviSession = newWeb({
+      debugging: import.meta.env.DEV,
+      element: "#yivi-web-form",
+      language: "en",
+      session: {
+        url: apiEndpoint + "/v1",
+        start: {
+          url: (o: any) => `${o.url}/session/`,
+          method: "POST",
+          credentials: "include",
         },
-      });
+        result: {
+          url: (o: any, { sessionToken }: any) =>
+            `${o.url}/token/${sessionToken}`,
+          method: "GET",
+          credentials: "include",
+        },
+      },
+    });
 
-      web.start().then((result: any) => {
+    web
+      .start()
+      .then((result: any) => {
         setAccessToken(result.access);
         if (location.state?.from) {
           navigate(location.state.from.pathname, { replace: true });
         } else {
           navigate(-1);
         }
+      })
+      .catch((err: unknown) => {
+        if (err !== "Aborted") {
+          console.error("Yivi session error:", err);
+        }
       });
-    });
 
-    return () => web?.abort();
+    return () => {
+      web.abort();
+    };
   }, [navigate, setAccessToken, location]);
 
   return (

--- a/portal_spa/src/pages/LoginPage.tsx
+++ b/portal_spa/src/pages/LoginPage.tsx
@@ -1,20 +1,33 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { ShieldCheck } from "lucide-react";
+
 import { apiEndpoint } from "@/services/axiosInstance";
 import { newWeb, type YiviSession } from "@/services/yivi";
 import useStore from "@/store";
-import { useEffect } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 
 export default function Login() {
-  const setAccessToken = useStore((state) => state.setAccessToken);
+  const setAccessToken = useStore((s) => s.setAccessToken);
   const navigate = useNavigate();
   const location = useLocation();
+  const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     const web: YiviSession = newWeb({
       debugging: import.meta.env.DEV,
       element: "#yivi-web-form",
       language: "en",
+      minimal: true,
       session: {
         url: apiEndpoint + "/v1",
         start: {
@@ -42,7 +55,9 @@ export default function Login() {
         }
       })
       .catch((err: unknown) => {
-        if (err !== "Aborted") {
+        if (err === "Cancelled" || err === "TimedOut" || err === "Error") {
+          setAttempt((n) => n + 1);
+        } else if (err !== "Aborted") {
           console.error("Yivi session error:", err);
         }
       });
@@ -50,44 +65,87 @@ export default function Login() {
     return () => {
       web.abort();
     };
-  }, [navigate, setAccessToken, location]);
+  }, [navigate, setAccessToken, location, attempt]);
 
   return (
-    <div className="min-h-screen flex flex-col justify-center items-center p-10">
-      <p className="mb-3 text-gray-600 text-start max-w-md">
-        Scan the QR code with your Yivi app to authenticate with your email. If
-        you don't have the app, you can download it{" "}
-        <a
-          className="text-blue-600 hover:underline"
-          href="https://yivi.app/#download"
-        >
-          here
-        </a>
-        .
-      </p>
+    <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center bg-slate-50 px-4 py-12">
+      <Card className="w-full max-w-md border-slate-200 shadow-md">
+        <CardHeader className="space-y-2 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-slate-900 text-white">
+            <ShieldCheck className="h-6 w-6" />
+          </div>
+          <CardTitle className="text-2xl tracking-tight">
+            Sign in to Yivi Portal
+          </CardTitle>
+          <CardDescription className="text-slate-600">
+            Authenticate securely with your verified email credential.
+          </CardDescription>
+        </CardHeader>
 
-      <div
-        id="yivi-web-form"
-        data-testid="yivi-web-form"
-        className="mb-8 max-w-md w-full"
-      ></div>
-      <p className="my-10 text-gray-600 text-start">
-        Having trouble? Read our{" "}
-        <a
-          href="https://yivi.app/faq/"
-          className="text-blue-600 hover:underline"
-        >
-          frequently asked questions
-        </a>{" "}
-        or contact us at{" "}
-        <a
-          href="mailto:support@yivi.app"
-          className="text-blue-600 hover:underline"
-        >
-          support@yivi.app
-        </a>
-        .
-      </p>
+        <CardContent>
+          <div className="flex flex-col items-center">
+            <div className="flex h-[272px] w-[272px] items-center justify-center rounded-lg border border-slate-200 bg-white p-4">
+              <div
+                id="yivi-web-form"
+                data-testid="yivi-web-form"
+                key={attempt}
+              />
+            </div>
+          </div>
+
+          <Separator className="my-6" />
+
+          <ol className="space-y-3 text-sm text-slate-600">
+            <Step n={1}>
+              Open the{" "}
+              <a
+                className="font-medium text-slate-900 hover:underline"
+                href="https://yivi.app/#download"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Yivi app
+              </a>{" "}
+              on your phone.
+            </Step>
+            <Step n={2}>Scan the QR code shown above.</Step>
+            <Step n={3}>Approve disclosure of your email credential.</Step>
+          </ol>
+        </CardContent>
+
+        <CardFooter className="flex flex-col gap-2 border-t border-slate-100 pt-6 text-center text-xs text-slate-500">
+          <p>
+            Need help? Visit our{" "}
+            <a
+              href="https://yivi.app/faq/"
+              className="font-medium text-slate-700 hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              FAQ
+            </a>{" "}
+            or email{" "}
+            <a
+              href="mailto:support@yivi.app"
+              className="font-medium text-slate-700 hover:underline"
+            >
+              support@yivi.app
+            </a>
+            .
+          </p>
+        </CardFooter>
+      </Card>
     </div>
+  );
+}
+
+function Step({ n, children }: { n: number; children: React.ReactNode }) {
+  return (
+    <li className="flex gap-3">
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-slate-100 text-xs font-semibold text-slate-700">
+        {n}
+      </span>
+      <span>{children}</span>
+    </li>
   );
 }

--- a/portal_spa/src/services/yivi.ts
+++ b/portal_spa/src/services/yivi.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { YiviCore } from "@privacybydesign/yivi-core";
+import { YiviWeb } from "@privacybydesign/yivi-web";
+import { YiviPopup } from "@privacybydesign/yivi-popup";
+import { YiviClient } from "@privacybydesign/yivi-client";
+import "@privacybydesign/yivi-css";
+
+export interface YiviSession {
+  start: (...input: unknown[]) => Promise<unknown>;
+  abort: () => Promise<unknown>;
+}
+
+export function newWeb(options: any): YiviSession {
+  const core = new YiviCore(options);
+  core.use(YiviWeb);
+  core.use(YiviClient);
+  return {
+    start: core.start.bind(core),
+    abort: core.abort.bind(core),
+  };
+}
+
+export function newPopup(options: any): YiviSession {
+  const core = new YiviCore(options);
+  core.use(YiviPopup);
+  core.use(YiviClient);
+  return {
+    start: core.start.bind(core),
+    abort: core.abort.bind(core),
+  };
+}

--- a/portal_spa/src/types/yivi-frontend.d.ts
+++ b/portal_spa/src/types/yivi-frontend.d.ts
@@ -1,5 +1,0 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-declare module '@privacybydesign/yivi-frontend' {
-    const yivi: any;
-    export default yivi;
-}


### PR DESCRIPTION
## Summary
- Replaces the unmaintained `@privacybydesign/yivi-frontend@0.2.1` with the v1.x individual packages (`yivi-core`, `yivi-web`, `yivi-popup`, `yivi-client`, `yivi-css`). These emit Yivi universal links via `open.yivi.app` instead of the legacy `irma.app` URLs, so the QR code and same-device button now work with the iOS/Android universal-link handlers.
- Adds a small `src/services/yivi.ts` helper that re-creates `newWeb` / `newPopup` by composing the individual packages. This is intentional: the bundled `@privacybydesign/yivi-frontend@1.x` ESM build inlines `pngjs` and references `node:module` / `fs` / `zlib`, which Vite cannot resolve for the browser. Composing locally is what `yivi-frontend` itself does internally and keeps the call sites unchanged.
- Updates `LoginPage` and `DemoCredentialCard` to import `newWeb` / `newPopup` from the helper, drops the now-obsolete `yivi-frontend.d.ts` ambient module declaration, and silences the expected "Aborted" rejection on Login cleanup.

Closes #277