### PR TITLE
Redesign login page with minimal Yivi QR

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,8 @@ services:
       - 9000:5173
     depends_on:
       - django
+    environment:
+      - VITE_API_ENDPOINT=${VITE_API_ENDPOINT:-http://localhost:8000}
     volumes:
       - ./portal_spa:/app
       - /app/node_modules/ # This will exclude node_modules from syncing to the container and prevents a crash on a missing library when working on Mac.

--- a/portal_spa/src/pages/LoginPage.tsx
+++ b/portal_spa/src/pages/LoginPage.tsx
@@ -1,20 +1,33 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { ShieldCheck } from "lucide-react";
+
 import { apiEndpoint } from "@/services/axiosInstance";
 import { newWeb, type YiviSession } from "@/services/yivi";
 import useStore from "@/store";
-import { useEffect } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 
 export default function Login() {
-  const setAccessToken = useStore((state) => state.setAccessToken);
+  const setAccessToken = useStore((s) => s.setAccessToken);
   const navigate = useNavigate();
   const location = useLocation();
+  const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     const web: YiviSession = newWeb({
       debugging: import.meta.env.DEV,
       element: "#yivi-web-form",
       language: "en",
+      minimal: true,
       session: {
         url: apiEndpoint + "/v1",
         start: {
@@ -42,7 +55,9 @@ export default function Login() {
         }
       })
       .catch((err: unknown) => {
-        if (err !== "Aborted") {
+        if (err === "Cancelled" || err === "TimedOut" || err === "Error") {
+          setAttempt((n) => n + 1);
+        } else if (err !== "Aborted") {
           console.error("Yivi session error:", err);
         }
       });
@@ -50,44 +65,87 @@ export default function Login() {
     return () => {
       web.abort();
     };
-  }, [navigate, setAccessToken, location]);
+  }, [navigate, setAccessToken, location, attempt]);
 
   return (
-    <div className="min-h-screen flex flex-col justify-center items-center p-10">
-      <p className="mb-3 text-gray-600 text-start max-w-md">
-        Scan the QR code with your Yivi app to authenticate with your email. If
-        you don't have the app, you can download it{" "}
-        <a
-          className="text-blue-600 hover:underline"
-          href="https://yivi.app/#download"
-        >
-          here
-        </a>
-        .
-      </p>
+    <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center bg-slate-50 px-4 py-12">
+      <Card className="w-full max-w-md border-slate-200 shadow-md">
+        <CardHeader className="space-y-2 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-slate-900 text-white">
+            <ShieldCheck className="h-6 w-6" />
+          </div>
+          <CardTitle className="text-2xl tracking-tight">
+            Sign in to Yivi Portal
+          </CardTitle>
+          <CardDescription className="text-slate-600">
+            Authenticate securely with your verified email credential.
+          </CardDescription>
+        </CardHeader>
 
-      <div
-        id="yivi-web-form"
-        data-testid="yivi-web-form"
-        className="mb-8 max-w-md w-full"
-      ></div>
-      <p className="my-10 text-gray-600 text-start">
-        Having trouble? Read our{" "}
-        <a
-          href="https://yivi.app/faq/"
-          className="text-blue-600 hover:underline"
-        >
-          frequently asked questions
-        </a>{" "}
-        or contact us at{" "}
-        <a
-          href="mailto:support@yivi.app"
-          className="text-blue-600 hover:underline"
-        >
-          support@yivi.app
-        </a>
-        .
-      </p>
+        <CardContent>
+          <div className="flex flex-col items-center">
+            <div className="flex h-[272px] w-[272px] items-center justify-center rounded-lg border border-slate-200 bg-white p-4">
+              <div
+                id="yivi-web-form"
+                data-testid="yivi-web-form"
+                key={attempt}
+              />
+            </div>
+          </div>
+
+          <Separator className="my-6" />
+
+          <ol className="space-y-3 text-sm text-slate-600">
+            <Step n={1}>
+              Open the{" "}
+              <a
+                className="font-medium text-slate-900 hover:underline"
+                href="https://yivi.app/#download"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Yivi app
+              </a>{" "}
+              on your phone.
+            </Step>
+            <Step n={2}>Scan the QR code shown above.</Step>
+            <Step n={3}>Approve disclosure of your email credential.</Step>
+          </ol>
+        </CardContent>
+
+        <CardFooter className="flex flex-col gap-2 border-t border-slate-100 pt-6 text-center text-xs text-slate-500">
+          <p>
+            Need help? Visit our{" "}
+            <a
+              href="https://yivi.app/faq/"
+              className="font-medium text-slate-700 hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              FAQ
+            </a>{" "}
+            or email{" "}
+            <a
+              href="mailto:support@yivi.app"
+              className="font-medium text-slate-700 hover:underline"
+            >
+              support@yivi.app
+            </a>
+            .
+          </p>
+        </CardFooter>
+      </Card>
     </div>
+  );
+}
+
+function Step({ n, children }: { n: number; children: React.ReactNode }) {
+  return (
+    <li className="flex gap-3">
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-slate-100 text-xs font-semibold text-slate-700">
+        {n}
+      </span>
+      <span>{children}</span>
+    </li>
   );
 }


### PR DESCRIPTION
## Summary
- Redesign the login page around a corporate sign-in card (centered, slate palette, shield badge, numbered steps, support footer).
- Switch the Yivi QR rendering to ``yivi-web``'s ``minimal: true`` mode so only the QR (and its state animations) show — no Yivi header/helper chrome.
- Auto-restart the session on ``Cancelled`` / ``TimedOut`` / ``Error`` via an ``attempt`` counter so the QR re-issues without a manual refresh.
- Pass ``VITE_API_ENDPOINT`` into the ``react`` dev container in ``docker-compose.yml``. Without it, the SPA baked the literal placeholder ``%VITE_API_ENDPOINT%`` into request URLs and pages like ``/organizations`` failed with a 500 from Vite ("URI malformed").

## Notes
- Stacked on #284 — depends on the new ``@privacybydesign/yivi-core`` / ``yivi-web`` / ``yivi-client`` packages introduced there. Re-target to ``main`` once #284 merges.
- No new runtime dependencies.